### PR TITLE
Fix __all__ exports list in package init

### DIFF
--- a/src/templateer/__init__.py
+++ b/src/templateer/__init__.py
@@ -4,4 +4,4 @@
 from .models import TemplateModel
 from .discovery import discover_templates
 
-__all__ = ["TemplateModel, discover_templates"]
+__all__ = ["TemplateModel", "discover_templates"]


### PR DESCRIPTION
### Motivation
- Ensure the package correctly exports public API names by making `__all__` a proper list of identifiers instead of a single string.

### Description
- Replace the incorrect `__all__ = ["TemplateModel, discover_templates"]` with `__all__ = ["TemplateModel", "discover_templates"]` in `src/templateer/__init__.py`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d7ac3886883339dcd86abbcf4f7a3)