### PR TITLE
Add missing ClassVar and Template imports in models.py

### DIFF
--- a/src/templateer/models.py
+++ b/src/templateer/models.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import typing as _t
+from typing import ClassVar
 from pathlib import Path
 
 from pydantic import BaseModel
-from jinja2 import Environment, StrictUndefined
+from jinja2 import Environment, StrictUndefined, Template
 
 # Shared default Jinja environment used unless a subclass overrides it.
 _DEFAULT_ENV = Environment(


### PR DESCRIPTION
### Motivation
- Fix NameError risk by ensuring the type names used in annotations like `__template__: ClassVar[str]` and `_get_template(...) -> Template` are actually imported in `src/templateer/models.py`.

### Description
- Add `from typing import ClassVar` and include `Template` in the `jinja2` import line in `src/templateer/models.py` so the annotations resolve to real symbols.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d7abff2788333962fec991ef2da13)