### PR TITLE
Standardize template environment construction

### DIFF
--- a/src/templateer/models.py
+++ b/src/templateer/models.py
@@ -10,14 +10,13 @@ from pathlib import Path
 from pydantic import BaseModel
 from jinja2 import Environment, StrictUndefined, Template
 
-# Shared default Jinja environment used unless a subclass overrides it.
-_DEFAULT_ENV = Environment(
-    autoescape=False,
-    undefined=StrictUndefined,
-    trim_blocks=True,
-    lstrip_blocks=True,
-    keep_trailing_newline=True,
-)
+_DEFAULT_ENV_OPTIONS = {
+    "autoescape": False,
+    "undefined": StrictUndefined,
+    "trim_blocks": True,
+    "lstrip_blocks": True,
+    "keep_trailing_newline": True,
+}
 
 
 class TemplateBase(BaseModel):
@@ -30,19 +29,11 @@ class TemplateBase(BaseModel):
         if isinstance(getattr(cls, "__env__", None), Environment):
             return cls.__env__  # type: ignore[return-value]
 
+        env = Environment(**_DEFAULT_ENV_OPTIONS)
         if isinstance(getattr(cls, "__jinja_filters__", None), dict):
-            env = Environment(
-                autoescape=_DEFAULT_ENV.autoescape,
-                trim_blocks=_DEFAULT_ENV.trim_blocks,
-                lstrip_blocks=_DEFAULT_ENV.lstrip_blocks,
-            )
-            env.globals.update(_DEFAULT_ENV.globals)
-            env.filters.update(_DEFAULT_ENV.filters)
-            env.tests.update(_DEFAULT_ENV.tests)
             env.filters.update(cls.__jinja_filters__ or {})
-            return env
 
-        return _DEFAULT_ENV
+        return env
 
     @classmethod
     def _get_template(cls) -> Template:


### PR DESCRIPTION
### Motivation

- Ensure `TemplateBase._get_environment` always constructs a Jinja `Environment` with the same options (`StrictUndefined`, `trim_blocks`, `lstrip_blocks`, `keep_trailing_newline`) so behavior is identical whether or not custom filters are provided.
- Simplify environment setup and avoid special-case copying of globals/filters/tests when applying `__jinja_filters__`.

### Description

- Replace the shared `_DEFAULT_ENV` instance with an `_DEFAULT_ENV_OPTIONS` dict and always instantiate `Environment(**_DEFAULT_ENV_OPTIONS)` in `TemplateBase._get_environment`.
- Apply any provided `__jinja_filters__` by updating the created environment's `filters` mapping when `__jinja_filters__` is a `dict`.
- Preserve the existing behavior of returning a user-supplied `__env__` instance unchanged.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d7ba1d8988333940ac94fb1920426)