### PR TITLE
discover_templates: add cleanup option and improve import error reporting

### DIFF
--- a/src/templateer/discovery.py
+++ b/src/templateer/discovery.py
@@ -14,12 +14,19 @@ from uuid import uuid4
 from .models import TemplateModel
 
 
-def discover_templates(directory: str | Path = ".templateer") -> SimpleNamespace:
+def discover_templates(
+    directory: str | Path = ".templateer",
+    cleanup: bool = False,
+) -> SimpleNamespace:
     """Discover all TemplateModel subclasses in a directory.
 
     Loads each .py file under `directory` into a unique synthetic package so that
     relative imports between template modules (e.g., `from .x import Y`)
     work correctly during discovery and type identities match at runtime.
+
+    If `cleanup` is True, synthetic modules are removed from `sys.modules` after
+    discovery to avoid keeping temporary entries, but this means class identities
+    from discovered templates are not preserved across calls.
     """
     directory = Path(directory)
     if not directory.exists():
@@ -31,12 +38,15 @@ def discover_templates(directory: str | Path = ".templateer") -> SimpleNamespace
     # Use a unique package name per discovery call to avoid cross-call collisions
     PACKAGE_NAME = f"_templateer_pkg_{uuid4().hex}"
 
+    added_modules: list[str] = []
+
     try:
         # Create a synthetic package rooted at the template directory so
         # intra-template relative imports resolve (e.g., from .foo import Bar).
         pkg = types.ModuleType(PACKAGE_NAME)
         pkg.__path__ = [str(directory)]  # type: ignore[attr-defined]
         sys.modules[PACKAGE_NAME] = pkg
+        added_modules.append(PACKAGE_NAME)
 
         # Allow absolute imports that might rely on the parent being importable.
         sys.path.insert(0, str(directory.parent))
@@ -74,11 +84,18 @@ def discover_templates(directory: str | Path = ".templateer") -> SimpleNamespace
 
                     module = importlib.util.module_from_spec(spec)
                     sys.modules[module_name] = module
-                    spec.loader.exec_module(module)
+                    added_modules.append(module_name)
+                    try:
+                        spec.loader.exec_module(module)
+                    except Exception as exc:
+                        raise ImportError(
+                            f"Failed to import template module from {py_file}"
+                        ) from exc
                     loaded_modules.append(module)
                     progress_made = True
-                except Exception:
+                except ImportError:
                     # File failed to import - will retry on next pass
+                    failed_files.add(py_file)
                     pass
 
             # If no modules loaded this pass, we're done
@@ -96,7 +113,11 @@ def discover_templates(directory: str | Path = ".templateer") -> SimpleNamespace
                 continue
     finally:
         # Restore sys.path but keep the synthetic package in sys.modules to
-        # preserve class identities across instances/validation.
+        # preserve class identities across instances/validation unless cleanup
+        # is requested.
         sys.path = original_path
+        if cleanup:
+            for module_name in reversed(added_modules):
+                sys.modules.pop(module_name, None)
 
     return SimpleNamespace(**templates)


### PR DESCRIPTION
### Motivation

- Surface import failures with a clear `ImportError` that includes the source file path while preserving the original exception as the `__cause__`.
- Allow callers to avoid leaving synthetic package/modules in `sys.modules` after discovery to reduce global state pollution.

### Description

- Add an optional `cleanup: bool = False` parameter to `discover_templates` and document the behavior in the function docstring.
- Track synthetic modules in an `added_modules` list so they can be removed from `sys.modules` when `cleanup` is True.
- Wrap `spec.loader.exec_module(module)` in a `try/except` and raise `ImportError(f"Failed to import template module from {py_file}") from exc` to include the file path and preserve the original exception.
- Update import-failure handling to treat raised `ImportError` as a retryable failure and record failed files for subsequent passes.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d7ba39ab083338bdbd14ddcb8a450)