### PR TITLE
Fix method indentation in dataclass template

### DIFF
--- a/src/examples/.templateer/dataclass.py
+++ b/src/examples/.templateer/dataclass.py
@@ -12,8 +12,7 @@ class {{ class_name }}:
     {{ name }}: {{ field_type }}
 {% endfor %}
 {% for method in methods %}
-
-    {{ method | indent(4, true) }}
+{{ method | indent(4, true) }}
 {% endfor %}
 '''
 


### PR DESCRIPTION
### Motivation
- Ensure the dataclass example template does not produce double-indented or blank lines before method definitions so generated code uses correct Python indentation.

### Description
- In `src/examples/.templateer/dataclass.py` remove the extra blank line and leading spaces around the method insertion in `TEMPLATE` by replacing the indented `    {{ method | indent(4, true) }}` block with `{{ method | indent(4, true) }}`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d7bad6a74833396a7647c9571a909)