### PR TITLE
Implement roadmap step 1 skeleton (package, CLI, tests, scripts)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,15 +19,10 @@ classifiers = [
 ]
 
 dependencies = [
-    #"confidantic",
     "jinja2>=3.1.6",
     "pydantic>=2.12.4",
     "python-dotenv>=1.1.0",
 ]
-
-#[tool.uv.sources]
-#confidantic = { git = "https://github.com/Bullish-Design/confidantic.git" }
-
 
 [project.optional-dependencies]
 test = [
@@ -39,7 +34,7 @@ dev = [
 ]
 
 [project.scripts]
-demo = "examples.generate:main"
+mpt = "templateer.cli:app"
 
 [project.urls]
 Homepage = "https://github.com/Bullish-Design/templateer"
@@ -49,24 +44,21 @@ Repository = "https://github.com/Bullish-Design/templateer"
 line-length = 120
 target-version = "py313"
 select = [
-    "E", "W",    # pycodestyle
-    "F",         # pyflakes
-    "I",         # isort
-    "N",         # pep8-naming
-    "UP",        # pyupgrade
-    "B",         # flake8-bugbear
+    "E", "W",
+    "F",
+    "I",
+    "N",
+    "UP",
+    "B",
 ]
 
 [tool.pytest.ini_options]
 addopts = "-ra -q"
-testpaths = ["src/tests"]
+testpaths = ["tests"]
 markers = [
     "integration: marks tests as integration tests (skipped without env)",
 ]
 filterwarnings = "ignore::DeprecationWarning"
 
-
 [tool.hatch.build.targets.wheel]
-packages = [ "src/templateer","src/examples"] # "src/tests", 
-
-
+packages = ["src/templateer"]

--- a/scripts/dev_watch
+++ b/scripts/dev_watch
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v entr >/dev/null 2>&1; then
+  echo "entr is required for scripts/dev_watch"
+  echo "Install entr or run: pytest -q"
+  exit 1
+fi
+
+rg --files src tests pyproject.toml | entr -c pytest -q

--- a/src/templateer/__init__.py
+++ b/src/templateer/__init__.py
@@ -1,0 +1,5 @@
+"""Templateer package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.3.2"

--- a/src/templateer/cli.py
+++ b/src/templateer/cli.py
@@ -1,0 +1,24 @@
+"""CLI entrypoint for Templateer."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="mpt", description="Templateer CLI")
+    parser.add_argument("--version", action="store_true", help="Show version and exit")
+    return parser
+
+
+def app(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.version:
+        print("templateer")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(app())

--- a/src/templateer/env.py
+++ b/src/templateer/env.py
@@ -1,0 +1,1 @@
+"""Module placeholder for roadmap Step 1."""

--- a/src/templateer/errors.py
+++ b/src/templateer/errors.py
@@ -1,0 +1,1 @@
+"""Module placeholder for roadmap Step 1."""

--- a/src/templateer/importers.py
+++ b/src/templateer/importers.py
@@ -1,0 +1,1 @@
+"""Module placeholder for roadmap Step 1."""

--- a/src/templateer/logging_.py
+++ b/src/templateer/logging_.py
@@ -1,0 +1,1 @@
+"""Module placeholder for roadmap Step 1."""

--- a/src/templateer/manifest.py
+++ b/src/templateer/manifest.py
@@ -1,0 +1,1 @@
+"""Module placeholder for roadmap Step 1."""

--- a/src/templateer/output.py
+++ b/src/templateer/output.py
@@ -1,0 +1,1 @@
+"""Module placeholder for roadmap Step 1."""

--- a/src/templateer/registry.py
+++ b/src/templateer/registry.py
@@ -1,0 +1,1 @@
+"""Module placeholder for roadmap Step 1."""

--- a/src/templateer/renderer.py
+++ b/src/templateer/renderer.py
@@ -1,0 +1,1 @@
+"""Module placeholder for roadmap Step 1."""

--- a/src/templateer/uri.py
+++ b/src/templateer/uri.py
@@ -1,0 +1,1 @@
+"""Module placeholder for roadmap Step 1."""

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def test_import_templateer() -> None:
+    import templateer
+
+    assert templateer.__version__
+
+
+def test_cli_help() -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    result = subprocess.run(
+        [sys.executable, "-m", "templateer.cli", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert "Templateer CLI" in result.stdout


### PR DESCRIPTION
## Summary
- Created the initial `src/templateer/` package skeleton with the roadmap Step 1 modules:
  - `errors.py`, `uri.py`, `manifest.py`, `registry.py`, `env.py`, `importers.py`, `renderer.py`, `output.py`, `logging_.py`, `cli.py`
- Added a minimal CLI entrypoint in `templateer.cli` and wired `mpt` console script in `pyproject.toml`
- Updated packaging configuration to build from `src/templateer`
- Added test skeleton with smoke coverage for package import and CLI help output
- Added optional Linux helper script `scripts/dev_watch` that reruns tests using `entr`

## Validation
- `PYTHONPATH=src python -m templateer.cli --help`
- `PYTHONPATH=src pytest -q`

## Notes
- This PR intentionally implements only roadmap **Step 1** scaffolding and conventions; functional behavior for later steps remains to be added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb9b0ee5c833383792348579a075f)