### PR TITLE
Implement TemplateError hierarchy and secure URI validation

### DIFF
--- a/src/templateer/errors.py
+++ b/src/templateer/errors.py
@@ -1,1 +1,64 @@
-"""Module placeholder for roadmap Step 1."""
+"""Exception hierarchy for Templateer operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class TemplateError(Exception):
+    """Base exception for Templateer with contextual metadata.
+
+    Args:
+        message: Human-readable error description.
+        uri: Offending template URI when available.
+        action: Operation being attempted (for example: ``render`` or ``include``).
+        context: Arbitrary additional key/value context useful for debugging.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        uri: str | None = None,
+        action: str | None = None,
+        **context: Any,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.uri = uri
+        self.action = action
+        self.context = context
+
+    def __str__(self) -> str:
+        details: list[str] = []
+        if self.action:
+            details.append(f"action={self.action}")
+        if self.uri:
+            details.append(f"uri={self.uri}")
+        for key, value in self.context.items():
+            if value is not None:
+                details.append(f"{key}={value}")
+
+        if not details:
+            return self.message
+        return f"{self.message} ({', '.join(details)})"
+
+
+class RegistryError(TemplateError):
+    """Raised when registry operations fail."""
+
+
+class TemplateNotFoundError(TemplateError):
+    """Raised when a template ID or URI cannot be found."""
+
+
+class TemplateImportError(TemplateError):
+    """Raised when a configured model import fails."""
+
+
+class TemplateRenderError(TemplateError):
+    """Raised when template rendering fails."""
+
+
+class OutputWriteError(TemplateError):
+    """Raised when writing rendered output fails."""

--- a/src/templateer/uri.py
+++ b/src/templateer/uri.py
@@ -1,1 +1,82 @@
-"""Module placeholder for roadmap Step 1."""
+"""URI validation helpers for template paths.
+
+Template URIs are security-sensitive and must remain within ``templates/``.
+"""
+
+from __future__ import annotations
+
+import posixpath
+from pathlib import PurePosixPath
+
+from templateer.errors import TemplateRenderError
+
+_TEMPLATES_PREFIX = "templates"
+
+
+def _reject_backslashes(uri: str, *, action: str) -> None:
+    if "\\" in uri:
+        raise TemplateRenderError(
+            "Template URI must use POSIX separators and cannot contain backslashes",
+            uri=uri,
+            action=action,
+        )
+
+
+def _normalize_uri(uri: str) -> str:
+    normalized = posixpath.normpath(uri)
+    if normalized == ".":
+        return ""
+    return normalized
+
+
+def _reject_absolute_path(uri: str, *, action: str) -> None:
+    if uri.startswith("/") or PurePosixPath(uri).is_absolute():
+        raise TemplateRenderError("Template URI cannot be absolute", uri=uri, action=action)
+
+
+def _reject_traversal(uri: str, *, action: str) -> None:
+    parts = PurePosixPath(uri).parts
+    if any(part == ".." for part in parts):
+        raise TemplateRenderError(
+            "Template URI cannot contain path traversal segments",
+            uri=uri,
+            action=action,
+        )
+
+
+def _require_templates_prefix(uri: str, *, action: str) -> None:
+    path = PurePosixPath(uri)
+    if not path.parts or path.parts[0] != _TEMPLATES_PREFIX:
+        raise TemplateRenderError(
+            "Template URI must remain under templates/",
+            uri=uri,
+            action=action,
+        )
+
+
+def validate_template_uri(uri: str, *, action: str = "render") -> str:
+    """Validate and normalize a template URI.
+
+    Args:
+        uri: Candidate template URI.
+        action: Operation being attempted; included in raised errors.
+
+    Returns:
+        Canonicalized URI with POSIX separators.
+
+    Raises:
+        TemplateRenderError: If the URI violates security policy.
+    """
+
+    candidate = uri.strip()
+    if not candidate:
+        raise TemplateRenderError("Template URI cannot be empty", uri=uri, action=action)
+
+    _reject_backslashes(candidate, action=action)
+    _reject_absolute_path(candidate, action=action)
+
+    normalized = _normalize_uri(candidate)
+    _reject_traversal(normalized, action=action)
+    _require_templates_prefix(normalized, action=action)
+
+    return normalized

--- a/tests/test_uri_validation.py
+++ b/tests/test_uri_validation.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+from templateer.errors import TemplateRenderError
+from templateer.uri import validate_template_uri
+
+
+def test_validate_template_uri_accepts_valid_uri() -> None:
+    assert validate_template_uri("templates/invoice/template.mako") == "templates/invoice/template.mako"
+
+
+def test_validate_template_uri_normalizes_dot_segments() -> None:
+    assert (
+        validate_template_uri("templates/invoice/./partials/../template.mako")
+        == "templates/invoice/template.mako"
+    )
+
+
+def test_validate_template_uri_rejects_absolute() -> None:
+    with pytest.raises(TemplateRenderError) as exc:
+        validate_template_uri("/templates/invoice/template.mako")
+
+    assert "cannot be absolute" in str(exc.value)
+    assert "action=render" in str(exc.value)
+
+
+def test_validate_template_uri_rejects_backslashes() -> None:
+    with pytest.raises(TemplateRenderError) as exc:
+        validate_template_uri(r"templates\\invoice\\template.mako", action="include")
+
+    message = str(exc.value)
+    assert "cannot contain backslashes" in message
+    assert "action=include" in message
+
+
+def test_validate_template_uri_rejects_traversal() -> None:
+    with pytest.raises(TemplateRenderError) as exc:
+        validate_template_uri("templates/../../secrets.mako")
+
+    assert "cannot contain path traversal segments" in str(exc.value)
+
+
+def test_validate_template_uri_rejects_non_templates_root() -> None:
+    with pytest.raises(TemplateRenderError) as exc:
+        validate_template_uri("shared/template.mako", action="build")
+
+    message = str(exc.value)
+    assert "must remain under templates/" in message
+    assert "action=build" in message


### PR DESCRIPTION
### Motivation
- Enforce the roadmap Step 2 error surface and URI security policy so later layers have a consistent, actionable error model. 
- Prevent template resolution outside `templates/` by validating URIs with POSIX semantics and surfacing offending `uri`/`action` in errors.

### Description
- Add `TemplateError` base exception that stores `message`, `uri`, `action`, and arbitrary key/value `context` and renders those values in `__str__` for actionable messages. 
- Add concrete exceptions: `RegistryError`, `TemplateNotFoundError`, `TemplateImportError`, `TemplateRenderError`, and `OutputWriteError`. 
- Implement `validate_template_uri(uri: str, *, action: str = "render") -> str` plus internal helpers (`_reject_backslashes`, `_normalize_uri`, `_reject_absolute_path`, `_reject_traversal`, `_require_templates_prefix`) using `posixpath` and `pathlib.PurePosixPath`, and raise `TemplateRenderError` with `uri` and `action` on violations. 
- Add `tests/test_uri_validation.py` exercising normalized acceptances and rejection cases (absolute paths, backslashes, traversal, and non-`templates/` roots) and asserting action-aware error text.

### Testing
- Running `pytest -q` initially failed due to import path (test runner required `PYTHONPATH=src`).
- Ran `PYTHONPATH=src pytest -q` which executed the suite and passed (URI tests included). 
- Ran `PYTHONPATH=src python -m pytest -q tests/test_uri_validation.py` which passed and validated the implemented URI policy and error formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cbf26cc948333b3b1cbc86f6ff437)