### PR TITLE
Implement roadmap Step 3 manifest and registry contracts

### DIFF
--- a/src/templateer/errors.py
+++ b/src/templateer/errors.py
@@ -44,6 +44,10 @@ class TemplateError(Exception):
         return f"{self.message} ({', '.join(details)})"
 
 
+class ManifestError(TemplateError):
+    """Raised when manifest operations fail."""
+
+
 class RegistryError(TemplateError):
     """Raised when registry operations fail."""
 
@@ -62,3 +66,8 @@ class TemplateRenderError(TemplateError):
 
 class OutputWriteError(TemplateError):
     """Raised when writing rendered output fails."""
+
+
+# Backward-compatible aliases kept for earlier roadmap step tests.
+TemplateerError = TemplateError
+TemplateURIValidationError = TemplateRenderError

--- a/src/templateer/manifest.py
+++ b/src/templateer/manifest.py
@@ -1,1 +1,103 @@
-"""Module placeholder for roadmap Step 1."""
+"""Contracts and JSON helpers for per-template manifest files."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from templateer.errors import ManifestError
+
+
+@dataclass(eq=True)
+class TemplateManifest:
+    """Manifest metadata stored next to a template."""
+
+    model_import_path: str
+    description: str | None = None
+    tags: list[str] = field(default_factory=list)
+
+    @classmethod
+    def model_validate(cls, payload: dict[str, Any]) -> TemplateManifest:
+        if not isinstance(payload, dict):
+            raise ManifestError("manifest must be a JSON object")
+
+        allowed = {"model_import_path", "description", "tags"}
+        extra = set(payload) - allowed
+        if extra:
+            raise ManifestError("manifest contains unknown fields", fields=sorted(extra))
+
+        if "model_import_path" not in payload:
+            raise ManifestError("model_import_path is required")
+
+        import_path = _validate_model_import_path(payload["model_import_path"])
+        description = payload.get("description")
+        tags = payload.get("tags", [])
+
+        if description is not None and not isinstance(description, str):
+            raise ManifestError("description must be a string")
+
+        if not isinstance(tags, list) or any(not isinstance(tag, str) for tag in tags):
+            raise ManifestError("tags must be a list of strings")
+
+        return cls(model_import_path=import_path, description=description, tags=list(tags))
+
+    def model_dump(self) -> dict[str, Any]:
+        return {
+            "model_import_path": self.model_import_path,
+            "description": self.description,
+            "tags": list(self.tags),
+        }
+
+    def model_dump_json(self, *, indent: int | None = None) -> str:
+        return json.dumps(self.model_dump(), indent=indent)
+
+
+def _validate_model_import_path(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ManifestError("model_import_path must be a string")
+
+    candidate = value.strip()
+    if not candidate:
+        raise ManifestError("model_import_path is required")
+
+    if ":" not in candidate:
+        raise ManifestError("model_import_path must use 'pkg.module:ClassName' format")
+
+    module_part, class_part = candidate.split(":", 1)
+    if not module_part or not class_part:
+        raise ManifestError("model_import_path must use 'pkg.module:ClassName' format")
+
+    if any(not segment.isidentifier() for segment in module_part.split(".")):
+        raise ManifestError("model_import_path module must be a dotted python import path")
+
+    if not class_part.isidentifier():
+        raise ManifestError("model_import_path class must be a valid python identifier")
+
+    return candidate
+
+
+def load_manifest(path: str | Path) -> TemplateManifest:
+    """Load a template manifest from JSON file."""
+
+    manifest_path = Path(path)
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ManifestError("manifest file does not exist", path=str(manifest_path)) from exc
+    except json.JSONDecodeError as exc:
+        raise ManifestError("manifest is not valid JSON", path=str(manifest_path), detail=str(exc)) from exc
+
+    try:
+        return TemplateManifest.model_validate(payload)
+    except ManifestError as exc:
+        raise ManifestError("manifest validation failed", path=str(manifest_path), detail=str(exc)) from exc
+
+
+def dump_manifest(manifest: TemplateManifest, path: str | Path) -> None:
+    """Persist manifest JSON to disk."""
+
+    manifest_path = Path(path)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(manifest.model_dump_json(indent=2) + "\n", encoding="utf-8")

--- a/src/templateer/registry.py
+++ b/src/templateer/registry.py
@@ -1,1 +1,131 @@
-"""Module placeholder for roadmap Step 1."""
+"""Contracts and JSON helpers for template registry."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from templateer.errors import ManifestError, RegistryError, TemplateError
+from templateer.manifest import TemplateManifest, _validate_model_import_path
+from templateer.uri import validate_template_uri
+
+
+@dataclass(eq=True)
+class TemplateEntry(TemplateManifest):
+    """Runtime template registry entry."""
+
+    template_uri: str = ""
+    readme_uri: str | None = None
+
+    @classmethod
+    def model_validate(cls, payload: dict[str, Any]) -> TemplateEntry:
+        if not isinstance(payload, dict):
+            raise RegistryError("template entry must be a JSON object")
+
+        allowed = {"template_uri", "model_import_path", "description", "tags", "readme_uri"}
+        extra = set(payload) - allowed
+        if extra:
+            raise RegistryError("template entry contains unknown fields", fields=sorted(extra))
+
+        if "template_uri" not in payload:
+            raise RegistryError("template_uri is required")
+        if "model_import_path" not in payload:
+            raise RegistryError("model_import_path is required")
+
+        template_uri = validate_template_uri(str(payload["template_uri"]), action="build")
+        model_import_path = _validate_model_import_path(payload["model_import_path"])
+
+        description = payload.get("description")
+        tags = payload.get("tags", [])
+        readme_uri = payload.get("readme_uri")
+
+        if description is not None and not isinstance(description, str):
+            raise RegistryError("description must be a string")
+        if not isinstance(tags, list) or any(not isinstance(tag, str) for tag in tags):
+            raise RegistryError("tags must be a list of strings")
+        if readme_uri is not None:
+            readme_uri = validate_template_uri(str(readme_uri), action="build")
+
+        return cls(
+            template_uri=template_uri,
+            model_import_path=model_import_path,
+            description=description,
+            tags=list(tags),
+            readme_uri=readme_uri,
+        )
+
+    def model_dump(self) -> dict[str, Any]:
+        return {
+            "template_uri": self.template_uri,
+            "model_import_path": self.model_import_path,
+            "description": self.description,
+            "tags": list(self.tags),
+            "readme_uri": self.readme_uri,
+        }
+
+
+@dataclass(eq=True)
+class TemplateRegistry:
+    """Loaded registry mapping template_id -> template entry."""
+
+    templates: dict[str, TemplateEntry] = field(default_factory=dict)
+
+    @classmethod
+    def model_validate(cls, payload: dict[str, Any]) -> TemplateRegistry:
+        if not isinstance(payload, dict):
+            raise RegistryError("registry must be a JSON object")
+
+        extra = set(payload) - {"templates"}
+        if extra:
+            raise RegistryError("registry contains unknown fields", fields=sorted(extra))
+
+        raw_templates = payload.get("templates", {})
+        if not isinstance(raw_templates, dict):
+            raise RegistryError("templates must be an object of template_id -> entry")
+
+        templates: dict[str, TemplateEntry] = {}
+        for template_id, raw_entry in raw_templates.items():
+            if not isinstance(template_id, str) or not template_id.strip():
+                raise RegistryError("template_id cannot be empty")
+            if "/" in template_id or "\\" in template_id:
+                raise RegistryError("template_id must be a simple identifier", template_id=template_id)
+
+            entry = TemplateEntry.model_validate(raw_entry)
+            if entry.readme_uri is None:
+                entry.readme_uri = validate_template_uri(f"templates/{template_id}/README.md", action="build")
+            templates[template_id] = entry
+
+        return cls(templates=templates)
+
+    def model_dump(self) -> dict[str, Any]:
+        return {"templates": {template_id: entry.model_dump() for template_id, entry in self.templates.items()}}
+
+    def model_dump_json(self, *, indent: int | None = None) -> str:
+        return json.dumps(self.model_dump(), indent=indent)
+
+
+def load_registry(path: str | Path) -> TemplateRegistry:
+    """Load and validate the runtime registry JSON."""
+
+    registry_path = Path(path)
+    try:
+        payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RegistryError("registry file does not exist", path=str(registry_path)) from exc
+    except json.JSONDecodeError as exc:
+        raise RegistryError("registry is not valid JSON", path=str(registry_path), detail=str(exc)) from exc
+
+    try:
+        return TemplateRegistry.model_validate(payload)
+    except (RegistryError, ManifestError, TemplateError) as exc:
+        raise RegistryError("registry validation failed", path=str(registry_path), detail=str(exc)) from exc
+
+
+def dump_registry(registry: TemplateRegistry, path: str | Path) -> None:
+    """Write registry JSON to disk."""
+
+    registry_path = Path(path)
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(registry.model_dump_json(indent=2) + "\n", encoding="utf-8")

--- a/tests/test_dev_step_3.py
+++ b/tests/test_dev_step_3.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from templateer.errors import ManifestError, RegistryError
+from templateer.manifest import TemplateManifest, load_manifest
+from templateer.registry import TemplateRegistry, load_registry
+
+
+def test_step_3_contracts_exist() -> None:
+    assert TemplateManifest is not None
+    assert TemplateRegistry is not None
+
+
+def test_step_3_manifest_and_registry_acceptance(tmp_path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"model_import_path": "bad_path"}), encoding="utf-8")
+    with pytest.raises(ManifestError):
+        load_manifest(manifest_path)
+
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "templates": {
+                    "invoice": {
+                        "template_uri": "../secrets.mako",
+                        "model_import_path": "myapp.models:InvoiceTemplate",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(RegistryError):
+        load_registry(registry_path)
+
+
+def test_step_3_round_trip_json_helpers(tmp_path) -> None:
+    registry_path = tmp_path / "registry.json"
+    payload = {
+        "templates": {
+            "invoice": {
+                "template_uri": "templates/invoice/template.mako",
+                "model_import_path": "myapp.models:InvoiceTemplate",
+            }
+        }
+    }
+    registry_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    registry = load_registry(registry_path)
+    assert registry.templates["invoice"].readme_uri == "templates/invoice/README.md"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from templateer.errors import ManifestError
+from templateer.manifest import TemplateManifest, dump_manifest, load_manifest
+
+
+def test_manifest_rejects_invalid_model_import_path(tmp_path) -> None:
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps({"model_import_path": "not-valid"}), encoding="utf-8")
+
+    with pytest.raises(ManifestError) as exc:
+        load_manifest(path)
+
+    assert "model_import_path" in str(exc.value)
+    assert "pkg.module:ClassName" in str(exc.value)
+
+
+def test_manifest_round_trip(tmp_path) -> None:
+    path = tmp_path / "manifest.json"
+    manifest = TemplateManifest(
+        model_import_path="myapp.models:InvoiceTemplate",
+        description="Invoice renderer",
+        tags=["billing"],
+    )
+
+    dump_manifest(manifest, path)
+    loaded = load_manifest(path)
+
+    assert loaded == manifest

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from templateer.errors import RegistryError
+from templateer.registry import TemplateRegistry, dump_registry, load_registry
+
+
+def test_registry_rejects_uri_outside_templates_boundary(tmp_path) -> None:
+    path = tmp_path / "registry.json"
+    path.write_text(
+        json.dumps(
+            {
+                "templates": {
+                    "invoice": {
+                        "template_uri": "outside/invoice/template.mako",
+                        "model_import_path": "myapp.models:InvoiceTemplate",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RegistryError) as exc:
+        load_registry(path)
+
+    message = str(exc.value)
+    assert "templates/" in message
+    assert "build" in message
+
+
+def test_registry_round_trip_and_default_readme_uri(tmp_path) -> None:
+    path = tmp_path / "registry.json"
+    registry = TemplateRegistry.model_validate(
+        {
+            "templates": {
+                "invoice": {
+                    "template_uri": "templates/invoice/template.mako",
+                    "model_import_path": "myapp.models:InvoiceTemplate",
+                    "description": "Invoice renderer",
+                    "tags": ["billing"],
+                }
+            }
+        }
+    )
+
+    dump_registry(registry, path)
+    loaded = load_registry(path)
+
+    assert loaded.templates["invoice"].template_uri == "templates/invoice/template.mako"
+    assert loaded.templates["invoice"].readme_uri == "templates/invoice/README.md"
+    assert loaded.model_dump() == registry.model_dump()
+
+
+def test_registry_rejects_invalid_model_import_path(tmp_path) -> None:
+    path = tmp_path / "registry.json"
+    path.write_text(
+        json.dumps(
+            {
+                "templates": {
+                    "invoice": {
+                        "template_uri": "templates/invoice/template.mako",
+                        "model_import_path": "missing_colon",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RegistryError) as exc:
+        load_registry(path)
+
+    assert "model_import_path" in str(exc.value)


### PR DESCRIPTION
## Summary
- implemented `TemplateManifest` contract in `src/templateer/manifest.py`
  - required `model_import_path` validation in `pkg.module:ClassName` form
  - optional `description` and `tags`
  - JSON load/dump helpers with wrapped `ManifestError` messages
- implemented `TemplateEntry` and `TemplateRegistry` contracts in `src/templateer/registry.py`
  - validates `template_uri` and optional `readme_uri` through URI policy
  - enforces template-id shape and applies default `readme_uri` as `templates/<id>/README.md`
  - JSON load/dump helpers with wrapped `RegistryError` messages
- extended error surface in `src/templateer/errors.py` with `ManifestError` (plus compatibility aliases used by existing tests)
- added test coverage for Step 3:
  - `tests/test_manifest.py`
  - `tests/test_registry.py`
  - `tests/test_dev_step_3.py`

## Validation
- ran full test suite with `pytest -q` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ccfb147cc8333a802cb767fda3603)