### PR TITLE
Implement Step 4: TemplateEnv registry freshness reloading

### DIFF
--- a/src/templateer/env.py
+++ b/src/templateer/env.py
@@ -1,1 +1,101 @@
-"""Module placeholder for roadmap Step 1."""
+"""Template environment and registry freshness helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from templateer.errors import RegistryError
+from templateer.registry import TemplateRegistry, load_registry
+
+
+@dataclass(frozen=True)
+class _RegistrySignature:
+    """Filesystem signature used to detect registry changes."""
+
+    mtime_ns: int
+    size: int
+    inode: int | None
+
+
+class TemplateEnv:
+    """Runtime environment anchored to a project root.
+
+    The environment lazily loads ``templates/registry.json`` and reloads it when
+    the file signature changes.
+    """
+
+    def __init__(self, project_root: Path, clock: Callable[[], object] | None = None) -> None:
+        self.project_root = Path(project_root)
+        self.templates_dir = self.project_root / "templates"
+        self.output_dir = self.project_root / "output"
+        self.log_dir = self.project_root / "log"
+        self.clock = clock
+
+        self._cached_registry: TemplateRegistry | None = None
+        self._cached_signature: _RegistrySignature | None = None
+
+    @property
+    def registry_path(self) -> Path:
+        """Path to the authoritative template registry."""
+
+        return self.templates_dir / "registry.json"
+
+    def _path_for_message(self, path: Path) -> str:
+        """Format paths relative to project root for user-facing messages."""
+
+        try:
+            return path.relative_to(self.project_root).as_posix()
+        except ValueError:
+            return str(path)
+
+    def _current_signature(self) -> _RegistrySignature:
+        try:
+            stat = self.registry_path.stat()
+        except FileNotFoundError as exc:
+            rel_path = self._path_for_message(self.registry_path)
+            raise RegistryError(
+                "registry file does not exist",
+                path=rel_path,
+                hint="run the registry build command to create templates/registry.json",
+            ) from exc
+
+        return _RegistrySignature(
+            mtime_ns=stat.st_mtime_ns,
+            size=stat.st_size,
+            inode=getattr(stat, "st_ino", None),
+        )
+
+    def _load_registry(self) -> TemplateRegistry:
+        try:
+            return load_registry(self.registry_path)
+        except RegistryError as exc:
+            context = dict(exc.context)
+            raw_path = context.get("path")
+            if isinstance(raw_path, str):
+                context["path"] = self._path_for_message(Path(raw_path))
+            raise RegistryError(exc.message, uri=exc.uri, action=exc.action, **context) from exc
+
+    def get_registry(self) -> TemplateRegistry:
+        """Return the current registry, reloading it if the file changed."""
+
+        signature = self._current_signature()
+        if self._cached_registry is None or signature != self._cached_signature:
+            self._cached_registry = self._load_registry()
+            self._cached_signature = signature
+
+        return self._cached_registry
+
+    def get_entry(self, template_id: str):
+        """Resolve a template entry by ID from the fresh registry."""
+
+        registry = self.get_registry()
+        try:
+            return registry.templates[template_id]
+        except KeyError as exc:
+            raise RegistryError(
+                "template_id not found in registry",
+                template_id=template_id,
+                path=self._path_for_message(self.registry_path),
+            ) from exc

--- a/tests/test_dev_step_4.py
+++ b/tests/test_dev_step_4.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from templateer.env import TemplateEnv
+
+
+def test_step_4_contracts_exist() -> None:
+    assert TemplateEnv is not None
+
+
+def test_step_4_env_registry_path_convention(tmp_path) -> None:
+    env = TemplateEnv(tmp_path)
+    assert env.registry_path == tmp_path / "templates" / "registry.json"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from templateer.env import TemplateEnv
+from templateer.errors import RegistryError
+
+
+def _write_registry(project_root, template_uri: str, model_import_path: str) -> None:
+    registry_path = project_root / "templates" / "registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "templates": {
+            "invoice": {
+                "template_uri": template_uri,
+                "model_import_path": model_import_path,
+            }
+        }
+    }
+    registry_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_env_anchors_paths_to_project_root(tmp_path) -> None:
+    env = TemplateEnv(tmp_path)
+
+    assert env.templates_dir == tmp_path / "templates"
+    assert env.output_dir == tmp_path / "output"
+    assert env.log_dir == tmp_path / "log"
+    assert env.registry_path == tmp_path / "templates" / "registry.json"
+
+
+def test_env_reloads_registry_when_signature_changes(tmp_path) -> None:
+    env = TemplateEnv(tmp_path)
+    _write_registry(
+        tmp_path,
+        template_uri="templates/invoice/template_v1.mako",
+        model_import_path="myapp.models:InvoiceTemplateV1",
+    )
+
+    first = env.get_entry("invoice")
+    assert first.template_uri == "templates/invoice/template_v1.mako"
+    assert first.model_import_path == "myapp.models:InvoiceTemplateV1"
+
+    _write_registry(
+        tmp_path,
+        template_uri="templates/invoice/template_v2.mako",
+        model_import_path="myapp.models:InvoiceTemplateV2",
+    )
+
+    second = env.get_entry("invoice")
+    assert second.template_uri == "templates/invoice/template_v2.mako"
+    assert second.model_import_path == "myapp.models:InvoiceTemplateV2"
+
+
+def test_env_missing_registry_has_hint_and_relative_path(tmp_path) -> None:
+    env = TemplateEnv(tmp_path)
+
+    with pytest.raises(RegistryError) as exc:
+        env.get_registry()
+
+    message = str(exc.value)
+    assert "templates/registry.json" in message
+    assert "run the registry build command" in message


### PR DESCRIPTION
## Summary
- Implemented `TemplateEnv` in `src/templateer/env.py` with project-root anchored paths:
  - `templates_dir`, `output_dir`, `log_dir`
  - `registry_path` (`templates/registry.json`)
- Added registry freshness logic in `get_registry()` using a filesystem signature (`st_mtime_ns`, `st_size`, optional `st_ino`) so the registry reloads on next access when changed.
- Added `get_entry(template_id)` convenience lookup with a clear `RegistryError` when a template ID is missing.
- Added missing-registry handling that raises `RegistryError` with a root-relative path and a helpful hint to build the registry.
- Normalized error path context in env-wrapped registry load errors to keep user-facing messages root-relative.

## Tests
- Added `tests/test_env.py` covering:
  - path anchoring to project root
  - reload behavior after registry rewrite (v1 -> v2)
  - missing registry error contains `templates/registry.json` and a build hint
- Added `tests/test_dev_step_4.py` as an overall development-step check for Step 4 contract and path convention.
- Ran full test suite successfully:
  - `pytest -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd21e0b408333b08c6b68b6883a69)