### PR TITLE
Detect registry content changes by adding digest to signature

### DIFF
--- a/src/templateer/env.py
+++ b/src/templateer/env.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -17,6 +18,7 @@ class _RegistrySignature:
     mtime_ns: int
     size: int
     inode: int | None
+    digest: str
 
 
 class TemplateEnv:
@@ -53,6 +55,7 @@ class TemplateEnv:
     def _current_signature(self) -> _RegistrySignature:
         try:
             stat = self.registry_path.stat()
+            content = self.registry_path.read_bytes()
         except FileNotFoundError as exc:
             rel_path = self._path_for_message(self.registry_path)
             raise RegistryError(
@@ -65,6 +68,7 @@ class TemplateEnv:
             mtime_ns=stat.st_mtime_ns,
             size=stat.st_size,
             inode=getattr(stat, "st_ino", None),
+            digest=hashlib.blake2b(content, digest_size=16).hexdigest(),
         )
 
     def _load_registry(self) -> TemplateRegistry:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -54,6 +54,42 @@ def test_env_reloads_registry_when_signature_changes(tmp_path) -> None:
     assert second.model_import_path == "myapp.models:InvoiceTemplateV2"
 
 
+def test_env_reloads_registry_when_content_changes_with_same_size_payload(tmp_path) -> None:
+    env = TemplateEnv(tmp_path)
+    registry_path = env.registry_path
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+
+    first_payload = """{"templates":{"invoice":{"template_uri":"templates/invoice/template_v1.mako","model_import_path":"myapp.models:InvoiceTemplateAA"}}}"""
+    second_payload = """{"templates":{"invoice":{"template_uri":"templates/invoice/template_v2.mako","model_import_path":"myapp.models:InvoiceTemplateBB"}}}"""
+
+    assert len(first_payload) == len(second_payload)
+
+    registry_path.write_text(first_payload, encoding="utf-8")
+    first = env.get_entry("invoice")
+    assert first.template_uri == "templates/invoice/template_v1.mako"
+    assert first.model_import_path == "myapp.models:InvoiceTemplateAA"
+
+    signature_before = env._cached_signature
+    assert signature_before is not None
+
+    registry_path.write_text(second_payload, encoding="utf-8")
+    stat_after = registry_path.stat()
+
+    if signature_before.inode is not None and stat_after.st_ino != signature_before.inode:
+        pytest.skip("filesystem changed inode on rewrite; cannot assert inode stability")
+
+    if stat_after.st_size != signature_before.size:
+        pytest.skip("filesystem reported size change; cannot assert same-size rewrite")
+
+    if stat_after.st_mtime_ns != signature_before.mtime_ns:
+        registry_path.touch(ns=(signature_before.mtime_ns, signature_before.mtime_ns))
+
+    second = env.get_entry("invoice")
+    assert second.template_uri == "templates/invoice/template_v2.mako"
+    assert second.model_import_path == "myapp.models:InvoiceTemplateBB"
+    assert env._cached_signature != signature_before
+
+
 def test_env_missing_registry_has_hint_and_relative_path(tmp_path) -> None:
     env = TemplateEnv(tmp_path)
 


### PR DESCRIPTION
### Motivation
- The registry reload logic relied only on filesystem metadata (mtime/size/inode) which can miss semantic content changes when those metadata remain the same. 
- We want deterministic reloads whenever `templates/registry.json` content changes, even for same-size rewrites.
- Preserve existing error messages and relative-path formatting for `RegistryError` while improving freshness detection.

### Description
- Added a `digest` field to `_RegistrySignature` in `src/templateer/env.py` and imported `hashlib` to compute a content fingerprint. 
- Updated `_current_signature()` to read `self.registry_path` bytes and compute a BLAKE2b digest (`digest_size=16`) included in the returned signature while keeping `mtime_ns`, `size`, and `inode` for observability. 
- `get_registry()` continues to compare signatures for equality, so including the digest ensures rewritten-but-same-metadata content triggers a reload. 
- Added a regression test `test_env_reloads_registry_when_content_changes_with_same_size_payload` in `tests/test_env.py` that writes two equal-length but different payloads and asserts the environment reloads the registry; existing `RegistryError` behavior remains unchanged.

### Testing
- Ran `pytest -q tests/test_env.py`, which passed (all tests succeeded), including `test_env_reloads_registry_when_signature_changes` and the new same-size-content regression test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd599b81c8333a2883a88512aa957)