### PR TITLE
Implement roadmap Step 5 registry builder and CLI registry commands

### DIFF
--- a/src/templateer/cli.py
+++ b/src/templateer/cli.py
@@ -3,21 +3,58 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from collections.abc import Sequence
+from pathlib import Path
+
+from templateer import __version__
+from templateer.errors import TemplateError
+from templateer.registry import build_registry_file, load_registry
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="mpt", description="Templateer CLI")
     parser.add_argument("--version", action="store_true", help="Show version and exit")
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    registry_parser = subparsers.add_parser("registry", help="Registry operations")
+    registry_subparsers = registry_parser.add_subparsers(dest="registry_command")
+
+    registry_build = registry_subparsers.add_parser("build", help="Build templates/registry.json")
+    registry_build.add_argument("--project-root", type=Path, default=Path("."), help="Project root directory")
+
+    registry_show = registry_subparsers.add_parser("show", help="Show templates/registry.json")
+    registry_show.add_argument("--project-root", type=Path, default=Path("."), help="Project root directory")
+
     return parser
 
 
 def app(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    if args.version:
-        print("templateer")
-    return 0
+
+    try:
+        if args.version:
+            print(__version__)
+            return 0
+
+        if args.command == "registry" and args.registry_command == "build":
+            registry_path = build_registry_file(args.project_root)
+            print(registry_path)
+            return 0
+
+        if args.command == "registry" and args.registry_command == "show":
+            registry_path = Path(args.project_root) / "templates" / "registry.json"
+            registry = load_registry(registry_path)
+            print(registry.model_dump_json(indent=2))
+            return 0
+
+        parser.print_help()
+        return 0
+    except TemplateError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/src/templateer/registry.py
+++ b/src/templateer/registry.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from templateer.errors import ManifestError, RegistryError, TemplateError
-from templateer.manifest import TemplateManifest, _validate_model_import_path
+from templateer.manifest import TemplateManifest, _validate_model_import_path, load_manifest
 from templateer.uri import validate_template_uri
+
+_REQUIRED_TEMPLATE_FILES = ("template.mako", "manifest.json", "README.md")
 
 
 @dataclass(eq=True)
@@ -106,6 +110,111 @@ class TemplateRegistry:
         return json.dumps(self.model_dump(), indent=indent)
 
 
+def _as_project_relative(path: Path, project_root: Path) -> str:
+    try:
+        return path.relative_to(project_root).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _ensure_required_template_files(project_root: Path, template_id: str, template_dir: Path) -> None:
+    missing = [name for name in _REQUIRED_TEMPLATE_FILES if not (template_dir / name).is_file()]
+    if missing:
+        raise RegistryError(
+            "template folder is missing required files",
+            template_id=template_id,
+            path=_as_project_relative(template_dir, project_root),
+            missing=",".join(missing),
+        )
+
+
+def build_registry(project_root: str | Path) -> TemplateRegistry:
+    """Build an in-memory registry by scanning ``templates/*`` folders.
+
+    The build is deterministic: template IDs are sorted lexicographically.
+    """
+
+    root = Path(project_root)
+    templates_dir = root / "templates"
+    if not templates_dir.is_dir():
+        raise RegistryError(
+            "templates directory does not exist",
+            path=_as_project_relative(templates_dir, root),
+        )
+
+    entries: dict[str, dict[str, Any]] = {}
+    for candidate in sorted(templates_dir.iterdir(), key=lambda path: path.name):
+        if not candidate.is_dir():
+            continue
+
+        template_id = candidate.name
+        if template_id == "_shared":
+            continue
+
+        _ensure_required_template_files(root, template_id, candidate)
+
+        manifest_path = candidate / "manifest.json"
+        try:
+            manifest = load_manifest(manifest_path)
+        except ManifestError as exc:
+            raise RegistryError(
+                "manifest validation failed while building registry",
+                template_id=template_id,
+                path=_as_project_relative(manifest_path, root),
+                detail=str(exc),
+            ) from exc
+
+        entries[template_id] = {
+            "template_uri": f"templates/{template_id}/template.mako",
+            "model_import_path": manifest.model_import_path,
+            "description": manifest.description,
+            "tags": manifest.tags,
+            "readme_uri": f"templates/{template_id}/README.md",
+        }
+
+    return TemplateRegistry.model_validate({"templates": entries})
+
+
+def dump_registry_atomically(registry: TemplateRegistry, path: str | Path) -> None:
+    """Write registry JSON to disk atomically using ``os.replace``."""
+
+    registry_path = Path(path)
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = registry.model_dump_json(indent=2) + "\n"
+    temp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=registry_path.parent,
+            prefix=f".{registry_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temp_name = handle.name
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        os.replace(temp_name, registry_path)
+    finally:
+        if temp_name is not None:
+            temp_path = Path(temp_name)
+            if temp_path.exists():
+                temp_path.unlink()
+
+
+def build_registry_file(project_root: str | Path) -> Path:
+    """Build and persist ``templates/registry.json`` for a project root."""
+
+    root = Path(project_root)
+    registry = build_registry(root)
+    registry_path = root / "templates" / "registry.json"
+    dump_registry_atomically(registry, registry_path)
+    return registry_path
+
+
 def load_registry(path: str | Path) -> TemplateRegistry:
     """Load and validate the runtime registry JSON."""
 
@@ -126,6 +235,4 @@ def load_registry(path: str | Path) -> TemplateRegistry:
 def dump_registry(registry: TemplateRegistry, path: str | Path) -> None:
     """Write registry JSON to disk."""
 
-    registry_path = Path(path)
-    registry_path.parent.mkdir(parents=True, exist_ok=True)
-    registry_path.write_text(registry.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    dump_registry_atomically(registry, path)

--- a/tests/test_dev_step_5.py
+++ b/tests/test_dev_step_5.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from templateer.cli import app
+from templateer.registry import build_registry, build_registry_file
+
+
+def test_step_5_contracts_exist() -> None:
+    assert callable(build_registry)
+    assert callable(build_registry_file)
+
+
+def test_step_5_cli_registry_commands_exist() -> None:
+    with pytest.raises(SystemExit) as build_help:
+        app(["registry", "build", "--help"])
+    assert build_help.value.code == 0
+
+    with pytest.raises(SystemExit) as show_help:
+        app(["registry", "show", "--help"])
+    assert show_help.value.code == 0

--- a/tests/test_registry_builder.py
+++ b/tests/test_registry_builder.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from templateer.errors import RegistryError
+from templateer.registry import build_registry, build_registry_file, load_registry
+
+
+def _write_template(template_dir: Path, model_import_path: str = "acme.models:Invoice") -> None:
+    template_dir.mkdir(parents=True, exist_ok=True)
+    (template_dir / "template.mako").write_text("hello ${name}", encoding="utf-8")
+    (template_dir / "README.md").write_text("# Template", encoding="utf-8")
+    (template_dir / "manifest.json").write_text(
+        json.dumps({"model_import_path": model_import_path, "description": "desc", "tags": ["a"]}),
+        encoding="utf-8",
+    )
+
+
+def test_build_registry_scans_templates_and_excludes_shared(tmp_path) -> None:
+    templates_dir = tmp_path / "templates"
+    _write_template(templates_dir / "zeta", "pkg.mod:ZetaModel")
+    _write_template(templates_dir / "alpha", "pkg.mod:AlphaModel")
+    _write_template(templates_dir / "_shared", "pkg.mod:SharedModel")
+
+    registry = build_registry(tmp_path)
+
+    assert list(registry.templates) == ["alpha", "zeta"]
+    assert registry.templates["alpha"].template_uri == "templates/alpha/template.mako"
+    assert registry.templates["alpha"].readme_uri == "templates/alpha/README.md"
+    assert registry.templates["alpha"].model_import_path == "pkg.mod:AlphaModel"
+
+
+def test_build_registry_fails_if_required_file_missing(tmp_path) -> None:
+    template_dir = tmp_path / "templates" / "invoice"
+    template_dir.mkdir(parents=True)
+    (template_dir / "manifest.json").write_text(json.dumps({"model_import_path": "pkg.mod:Invoice"}), encoding="utf-8")
+
+    with pytest.raises(RegistryError) as exc:
+        build_registry(tmp_path)
+
+    message = str(exc.value)
+    assert "missing required files" in message
+    assert "template.mako" in message
+    assert "README.md" in message
+
+
+def test_build_registry_does_not_import_model_modules(tmp_path) -> None:
+    # Uses an import path that would fail if import execution were attempted.
+    _write_template(tmp_path / "templates" / "invoice", "does.not.exist:NeverImported")
+
+    registry = build_registry(tmp_path)
+
+    assert registry.templates["invoice"].model_import_path == "does.not.exist:NeverImported"
+
+
+def test_build_registry_file_writes_registry_json(tmp_path) -> None:
+    _write_template(tmp_path / "templates" / "invoice", "pkg.mod:InvoiceModel")
+
+    registry_path = build_registry_file(tmp_path)
+
+    assert registry_path == tmp_path / "templates" / "registry.json"
+    loaded = load_registry(registry_path)
+    assert "invoice" in loaded.templates
+
+
+def test_cli_registry_build_and_show(tmp_path) -> None:
+    _write_template(tmp_path / "templates" / "invoice", "pkg.mod:InvoiceModel")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+
+    build_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "templateer.cli",
+            "registry",
+            "build",
+            "--project-root",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert build_result.returncode == 0
+    assert str(tmp_path / "templates" / "registry.json") in build_result.stdout
+
+    show_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "templateer.cli",
+            "registry",
+            "show",
+            "--project-root",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert show_result.returncode == 0
+    payload = json.loads(show_result.stdout)
+    assert payload["templates"]["invoice"]["template_uri"] == "templates/invoice/template.mako"


### PR DESCRIPTION
## Summary
- Implemented deterministic registry building from `templates/*` directories (excluding `_shared`) without importing model code.
- Added required-file validation for each template folder (`template.mako`, `manifest.json`, `README.md`).
- Added atomic registry writes via temp-file + `os.replace`.
- Added public helpers to build in-memory registry and persist `templates/registry.json`.
- Expanded CLI with:
  - `mpt registry build --project-root <path>`
  - `mpt registry show --project-root <path>`
- Added Step 5 validation test file and focused builder/CLI tests.

## Files changed
- `src/templateer/registry.py`
- `src/templateer/cli.py`
- `tests/test_registry_builder.py`
- `tests/test_dev_step_5.py`

## Validation
- Ran full test suite with `pytest -q` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd744f18c83339c7464776f7a9c9a)