### PR TITLE
Implement roadmap Step 6: model import and JSON input validation

### DIFF
--- a/src/templateer/__init__.py
+++ b/src/templateer/__init__.py
@@ -1,5 +1,14 @@
 """Templateer package."""
 
-__all__ = ["__version__"]
+from templateer.importers import import_model, parse_model_input_data, parse_model_input_json
+from templateer.model import TemplateModel
 
-__version__ = "0.3.2"
+__all__ = [
+    "TemplateModel",
+    "__version__",
+    "import_model",
+    "parse_model_input_data",
+    "parse_model_input_json",
+]
+
+__version__ = "0.4.1"

--- a/src/templateer/errors.py
+++ b/src/templateer/errors.py
@@ -60,6 +60,10 @@ class TemplateImportError(TemplateError):
     """Raised when a configured model import fails."""
 
 
+class TemplateValidationError(TemplateError):
+    """Raised when user-provided template input does not validate."""
+
+
 class TemplateRenderError(TemplateError):
     """Raised when template rendering fails."""
 

--- a/src/templateer/importers.py
+++ b/src/templateer/importers.py
@@ -1,1 +1,94 @@
-"""Module placeholder for roadmap Step 1."""
+"""Model import and JSON input validation helpers."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+from templateer.errors import TemplateImportError, TemplateValidationError
+
+
+def import_model(path: str) -> type[BaseModel]:
+    """Import and return a Pydantic model class from ``pkg.module:ClassName``."""
+
+    if not isinstance(path, str):
+        raise TemplateImportError(
+            "model import path must be a string",
+            import_path=repr(path),
+        )
+
+    raw_path = path
+    candidate = path.strip()
+    if candidate.count(":") != 1:
+        raise TemplateImportError(
+            "model import path must contain exactly one ':'",
+            import_path=raw_path,
+        )
+
+    module_name, class_name = candidate.split(":", 1)
+    if not module_name or not class_name:
+        raise TemplateImportError(
+            "model import path must use 'pkg.module:ClassName' format",
+            import_path=raw_path,
+        )
+
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:
+        raise TemplateImportError(
+            "failed to import model module",
+            import_path=raw_path,
+            detail=str(exc),
+        ) from exc
+
+    try:
+        model_obj = getattr(module, class_name)
+    except AttributeError as exc:
+        raise TemplateImportError(
+            "model class was not found in module",
+            import_path=raw_path,
+            module=module_name,
+            class_name=class_name,
+        ) from exc
+
+    if not isinstance(model_obj, type) or not issubclass(model_obj, BaseModel):
+        raise TemplateImportError(
+            "imported symbol is not a pydantic BaseModel subclass",
+            import_path=raw_path,
+            module=module_name,
+            class_name=class_name,
+        )
+
+    return model_obj
+
+
+def parse_model_input_json(raw_json: str, model_class: type[BaseModel]) -> BaseModel:
+    """Parse and validate raw JSON input against a Pydantic model class."""
+
+    try:
+        payload = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        raise TemplateValidationError("input is not valid JSON", detail=str(exc)) from exc
+
+    if not isinstance(payload, dict):
+        raise TemplateValidationError("input JSON must be an object at the top level")
+
+    try:
+        return model_class.model_validate(payload)
+    except ValidationError as exc:
+        raise TemplateValidationError("input validation failed", detail=str(exc)) from exc
+
+
+def parse_model_input_data(data: Any, model_class: type[BaseModel]) -> BaseModel:
+    """Validate Python data against a Pydantic model class."""
+
+    if not isinstance(data, dict):
+        raise TemplateValidationError("input data must be a mapping")
+
+    try:
+        return model_class.model_validate(data)
+    except ValidationError as exc:
+        raise TemplateValidationError("input validation failed", detail=str(exc)) from exc

--- a/src/templateer/model.py
+++ b/src/templateer/model.py
@@ -1,0 +1,11 @@
+"""Pydantic model base class for template inputs."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class TemplateModel(BaseModel):
+    """Base template input model with strict field validation."""
+
+    model_config = ConfigDict(extra="forbid")

--- a/tests/test_dev_step_6.py
+++ b/tests/test_dev_step_6.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from templateer.importers import import_model, parse_model_input_json
+from templateer.model import TemplateModel
+
+
+class _Step6Model(TemplateModel):
+    value: int
+
+
+def test_step_6_contracts_exist() -> None:
+    assert callable(import_model)
+    assert callable(parse_model_input_json)
+    assert TemplateModel is not None
+
+
+def test_step_6_import_and_validation_smoke() -> None:
+    model_cls = import_model("tests.test_dev_step_6:_Step6Model")
+    instance = parse_model_input_json('{"value": 7}', model_cls)
+
+    assert instance.value == 7

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from templateer.errors import TemplateImportError, TemplateValidationError
+from templateer.importers import import_model, parse_model_input_json
+from templateer.model import TemplateModel
+
+
+class LocalValidModel(TemplateModel):
+    name: str
+
+
+class NotAModel:
+    pass
+
+
+def test_import_model_good_path() -> None:
+    model = import_model("tests.test_importers:LocalValidModel")
+    assert model is LocalValidModel
+
+
+def test_import_model_module_missing() -> None:
+    with pytest.raises(TemplateImportError) as exc:
+        import_model("doesnotexist_pkg.module:Anything")
+
+    message = str(exc.value)
+    assert "doesnotexist_pkg.module:Anything" in message
+    assert "failed to import model module" in message
+
+
+def test_import_model_class_missing() -> None:
+    with pytest.raises(TemplateImportError) as exc:
+        import_model("tests.test_importers:MissingClass")
+
+    message = str(exc.value)
+    assert "tests.test_importers:MissingClass" in message
+    assert "not found" in message
+
+
+def test_import_model_symbol_not_pydantic_model() -> None:
+    with pytest.raises(TemplateImportError) as exc:
+        import_model("tests.test_importers:NotAModel")
+
+    message = str(exc.value)
+    assert "tests.test_importers:NotAModel" in message
+    assert "BaseModel" in message
+
+
+def test_import_model_requires_exactly_one_colon() -> None:
+    with pytest.raises(TemplateImportError):
+        import_model("tests.test_importers.LocalValidModel")
+
+    with pytest.raises(TemplateImportError):
+        import_model("tests.test_importers:LocalValidModel:extra")
+
+
+def test_parse_model_input_json_rejects_extra_fields() -> None:
+    with pytest.raises(TemplateValidationError) as exc:
+        parse_model_input_json('{"name":"ok","extra":"nope"}', LocalValidModel)
+
+    message = str(exc.value).lower()
+    assert "validation" in message
+    assert "extra" in message
+
+
+def test_parse_model_input_json_rejects_non_object() -> None:
+    with pytest.raises(TemplateValidationError):
+        parse_model_input_json('["not", "an", "object"]', LocalValidModel)


### PR DESCRIPTION
## Summary
- Implemented `templateer.importers.import_model(path)` with strict `pkg.module:ClassName` parsing.
- Added robust import error handling for:
  - invalid path format
  - missing module
  - missing class
  - imported symbol not inheriting from `pydantic.BaseModel`
- Added JSON/data validation helpers:
  - `parse_model_input_json(raw_json, model_class)`
  - `parse_model_input_data(data, model_class)`
- Added `TemplateModel` base class in `templateer/model.py` with `extra='forbid'` via Pydantic config.
- Added `TemplateValidationError` in the error hierarchy.
- Exported new API in `templateer.__init__`.

## Tests
- Added `tests/test_importers.py` covering:
  - good import path
  - module missing
  - class missing
  - non-Pydantic class
  - exact-colon format requirement
  - extra JSON field rejection
  - non-object JSON rejection
- Added required dev-step gate test `tests/test_dev_step_6.py` to verify Step 6 contracts and smoke behavior.

## Validation run
- `pytest -q tests/test_importers.py tests/test_dev_step_6.py` failed in this environment due to missing `pydantic` dependency.
- Attempted dependency install (`python -m pip install pydantic`) but network/proxy restrictions prevented installation.
- `python -m compileall src tests` passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cda8c40508333984bab185e2edf9a)