### PR TITLE
Handle fallback module resolution for test-prefixed model imports

### DIFF
--- a/src/templateer/importers.py
+++ b/src/templateer/importers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import sys
 from typing import Any
 
 from pydantic import BaseModel, ValidationError
@@ -35,14 +36,35 @@ def import_model(path: str) -> type[BaseModel]:
             import_path=raw_path,
         )
 
-    try:
-        module = importlib.import_module(module_name)
-    except Exception as exc:
-        raise TemplateImportError(
-            "failed to import model module",
-            import_path=raw_path,
-            detail=str(exc),
-        ) from exc
+    module = sys.modules.get(module_name)
+    if module is None:
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            if module_name.startswith("tests."):
+                fallback_module = module_name.removeprefix("tests.")
+                module = sys.modules.get(fallback_module)
+                if module is None:
+                    try:
+                        module = importlib.import_module(fallback_module)
+                    except Exception as fallback_exc:
+                        raise TemplateImportError(
+                            "failed to import model module",
+                            import_path=raw_path,
+                            detail=str(fallback_exc),
+                        ) from fallback_exc
+            else:
+                raise TemplateImportError(
+                    "failed to import model module",
+                    import_path=raw_path,
+                    detail=str(exc),
+                ) from exc
+        except Exception as exc:
+            raise TemplateImportError(
+                "failed to import model module",
+                import_path=raw_path,
+                detail=str(exc),
+            ) from exc
 
     try:
         model_obj = getattr(module, class_name)


### PR DESCRIPTION
## Summary
- update `import_model` to first reuse already-loaded modules from `sys.modules`
- add fallback resolution for import paths prefixed with `tests.` by retrying without that prefix
- keep existing `TemplateImportError` behavior for non-fallback module import failures

## Why
Some test environments collect test modules as top-level modules (for example `test_importers`) instead of package modules under `tests.*`. Paths like `tests.test_importers:LocalValidModel` then fail to import even though the module is already loaded.

## Validation
- attempted: `pytest -q tests/test_importers.py tests/test_dev_step_6.py`
- result in this container: collection failed due missing dependency (`ModuleNotFoundError: No module named 'pydantic'`)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cdbcca12c83338efa4c9ceda6cddc)