### PR TITLE
Implement roadmap Step 7 safe Mako rendering with include enforcement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 
 dependencies = [
     "jinja2>=3.1.6",
+    "mako>=1.3.0",
     "pydantic>=2.12.4",
     "python-dotenv>=1.1.0",
 ]

--- a/src/templateer/renderer.py
+++ b/src/templateer/renderer.py
@@ -1,1 +1,94 @@
-"""Module placeholder for roadmap Step 1."""
+"""Safe Mako rendering helpers."""
+
+from __future__ import annotations
+
+import posixpath
+from pathlib import Path
+from typing import Any
+
+from mako.lookup import TemplateLookup
+from mako import exceptions as mako_exceptions
+
+from templateer.errors import TemplateRenderError
+from templateer.importers import import_model, parse_model_input_data
+from templateer.uri import validate_template_uri
+
+
+class _SafeTemplateLookup(TemplateLookup):
+    """TemplateLookup that enforces template URI policy for targets and includes."""
+
+    def _resolve_template_uri(self, uri: str, relativeto: str | None = None, *, action: str) -> str:
+        candidate = uri.strip()
+        if not candidate:
+            raise TemplateRenderError("Template URI cannot be empty", uri=uri, action=action)
+
+        if action == "include":
+            raw_parts = Path(candidate).parts
+            if any(part == ".." for part in raw_parts):
+                raise TemplateRenderError(
+                    "Include URI cannot contain path traversal segments",
+                    uri=uri,
+                    action=action,
+                )
+
+        if not candidate.startswith("templates/") and relativeto:
+            base_uri = posixpath.dirname(relativeto)
+            candidate = posixpath.join(base_uri, candidate)
+
+        return validate_template_uri(candidate, action=action)
+
+    def get_template(self, uri: str, relativeto: str | None = None):  # type: ignore[override]
+        action = "include" if relativeto is not None else "render"
+        safe_uri = self._resolve_template_uri(uri, relativeto, action=action)
+
+        try:
+            return super().get_template(safe_uri, relativeto=None)
+        except TemplateRenderError:
+            raise
+        except Exception as exc:
+            raise TemplateRenderError(
+                "Template lookup failed",
+                uri=safe_uri,
+                action=action,
+                detail=str(exc),
+            ) from exc
+
+
+def _build_lookup(project_root: Path) -> _SafeTemplateLookup:
+    return _SafeTemplateLookup(
+        directories=[project_root.as_posix()],
+        strict_undefined=True,
+        filesystem_checks=True,
+        module_directory=None,
+    )
+
+
+def render_uri(env: Any, template_uri: str, context: dict[str, Any]) -> str:
+    """Render a template URI under ``templates/**`` with strict Mako behavior."""
+
+    safe_uri = validate_template_uri(template_uri, action="render")
+    lookup = _build_lookup(Path(env.project_root))
+
+    try:
+        template = lookup.get_template(safe_uri)
+        return template.render(**context)
+    except TemplateRenderError:
+        raise
+    except Exception as exc:
+        detail = mako_exceptions.text_error_template().render().strip()
+        raise TemplateRenderError(
+            "Template rendering failed",
+            uri=safe_uri,
+            action="render",
+            detail=detail or str(exc),
+        ) from exc
+
+
+def render_template_id(env: Any, template_id: str, json_data: dict[str, Any]) -> str:
+    """Resolve a template by id from registry, validate input, and render."""
+
+    entry = env.get_entry(template_id)
+    model_class = import_model(entry.model_import_path)
+    model = parse_model_input_data(json_data, model_class)
+    context = model.model_dump()
+    return render_uri(env, entry.template_uri, context)

--- a/tests/test_dev_step_7.py
+++ b/tests/test_dev_step_7.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from templateer.env import TemplateEnv
+from templateer.errors import TemplateRenderError
+from templateer.model import TemplateModel
+from templateer.renderer import render_template_id, render_uri
+
+
+class _Step7Model(TemplateModel):
+    value: str
+
+
+def _write_registry(project_root: Path) -> None:
+    payload = {
+        "templates": {
+            "step7": {
+                "template_uri": "templates/step7/template.mako",
+                "model_import_path": "tests.test_dev_step_7:_Step7Model",
+                "description": "",
+                "tags": [],
+                "readme_uri": "templates/step7/README.md",
+            }
+        }
+    }
+    (project_root / "templates" / "registry.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_step_7_renderer_contract_and_behavior(tmp_path: Path) -> None:
+    (tmp_path / "templates" / "step7").mkdir(parents=True)
+    (tmp_path / "templates" / "_shared").mkdir(parents=True)
+    (tmp_path / "templates" / "_shared" / "prefix.mako").write_text("prefix-", encoding="utf-8")
+    (tmp_path / "templates" / "step7" / "template.mako").write_text(
+        '<%include file="templates/_shared/prefix.mako"/>${value}', encoding="utf-8"
+    )
+    (tmp_path / "templates" / "step7" / "README.md").write_text("step7", encoding="utf-8")
+    _write_registry(tmp_path)
+
+    env = TemplateEnv(tmp_path)
+
+    assert callable(render_uri)
+    assert callable(render_template_id)
+    assert render_template_id(env, "step7", {"value": "ok"}) == "prefix-ok"
+
+    (tmp_path / "templates" / "step7" / "template.mako").write_text("${missing}", encoding="utf-8")
+    try:
+        render_uri(env, "templates/step7/template.mako", {})
+    except TemplateRenderError:
+        pass
+    else:
+        raise AssertionError("strict undefined should fail on missing variable")

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from templateer.env import TemplateEnv
+from templateer.errors import TemplateRenderError
+from templateer.renderer import render_template_id, render_uri
+
+
+from templateer.model import TemplateModel
+
+
+class RenderModel(TemplateModel):
+    name: str
+
+
+def _write_registry(project_root: Path, template_id: str = "invoice") -> None:
+    registry_payload = {
+        "templates": {
+            template_id: {
+                "template_uri": f"templates/{template_id}/template.mako",
+                "model_import_path": "tests.test_renderer:RenderModel",
+                "description": "",
+                "tags": [],
+                "readme_uri": f"templates/{template_id}/README.md",
+            }
+        }
+    }
+    (project_root / "templates" / "registry.json").write_text(json.dumps(registry_payload), encoding="utf-8")
+
+
+def test_render_uri_strict_undefined_raises(tmp_path: Path) -> None:
+    (tmp_path / "templates" / "invoice").mkdir(parents=True)
+    (tmp_path / "templates" / "invoice" / "template.mako").write_text("Hello ${name} ${missing}", encoding="utf-8")
+
+    env = TemplateEnv(tmp_path)
+
+    with pytest.raises(TemplateRenderError) as exc:
+        render_uri(env, "templates/invoice/template.mako", {"name": "Ada"})
+
+    assert "render" in str(exc.value)
+    assert "missing" in str(exc.value).lower()
+
+
+def test_include_escape_attempt_fails_fast(tmp_path: Path) -> None:
+    (tmp_path / "templates" / "invoice").mkdir(parents=True)
+    (tmp_path / "templates" / "invoice" / "template.mako").write_text(
+        '<%include file="../../secrets.mako"/>',
+        encoding="utf-8",
+    )
+
+    env = TemplateEnv(tmp_path)
+
+    with pytest.raises(TemplateRenderError) as exc:
+        render_uri(env, "templates/invoice/template.mako", {})
+
+    assert "include" in str(exc.value)
+    assert "traversal" in str(exc.value).lower()
+
+
+def test_include_shared_and_local_templates_work(tmp_path: Path) -> None:
+    (tmp_path / "templates" / "_shared").mkdir(parents=True)
+    (tmp_path / "templates" / "invoice").mkdir(parents=True)
+    (tmp_path / "templates" / "_shared" / "header.mako").write_text("HDR ${name}\n", encoding="utf-8")
+    (tmp_path / "templates" / "invoice" / "line.mako").write_text("LINE\n", encoding="utf-8")
+    (tmp_path / "templates" / "invoice" / "template.mako").write_text(
+        '<%include file="templates/_shared/header.mako"/><%include file="line.mako"/>',
+        encoding="utf-8",
+    )
+
+    env = TemplateEnv(tmp_path)
+    rendered = render_uri(env, "templates/invoice/template.mako", {"name": "Ada"})
+
+    assert rendered == "HDR Ada\nLINE\n"
+
+
+def test_symlinked_template_directory_renders_without_realpath(tmp_path: Path) -> None:
+    source_root = tmp_path / "actual_templates"
+    (source_root / "invoice").mkdir(parents=True)
+    (tmp_path / "templates" / "_shared").mkdir(parents=True)
+
+    (source_root / "invoice" / "template.mako").write_text(
+        '<%include file="templates/_shared/header.mako"/>${name}', encoding="utf-8"
+    )
+    (tmp_path / "templates" / "_shared" / "header.mako").write_text("Hi ", encoding="utf-8")
+
+    (tmp_path / "templates" / "invoice").symlink_to(source_root / "invoice", target_is_directory=True)
+    (tmp_path / "templates" / "invoice" / "README.md").write_text("readme", encoding="utf-8")
+    _write_registry(tmp_path)
+
+    env = TemplateEnv(tmp_path)
+    rendered = render_template_id(env, "invoice", {"name": "Ada"})
+
+    assert rendered == "Hi Ada"


### PR DESCRIPTION
## Summary
- implement `templateer.renderer` with:
  - `render_uri(env, template_uri, context)`
  - `render_template_id(env, template_id, json_data)`
- add a `_SafeTemplateLookup` wrapper around Mako `TemplateLookup` to enforce URI policy on render targets and include paths
- enforce strict Mako undefined behavior and disable compiled module cache output in template trees
- wire rendering by template ID through registry entry lookup + model import + input validation before rendering
- add `mako` dependency to `pyproject.toml`

## Tests
- add `tests/test_renderer.py` covering:
  - strict undefined failure on missing variable
  - include traversal escape rejection (`../../...`)
  - valid include behavior for shared and local templates
  - symlinked template directory rendering behavior
- add `tests/test_dev_step_7.py` as an end-to-end step check for Step 7 deliverables

## Notes
- `pytest` could not be executed fully in this environment because required dependencies (notably `pydantic`) are unavailable and package install is blocked by network/proxy restrictions.
- `python -m compileall src tests` was run successfully to validate syntax.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cdd7253d483339dbf42535fa01583)