### PR TITLE
Add JSONL batch demo generator script and README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,23 @@ Nested `TemplateModel` instances automatically render when referenced in templat
 ## License
 
 MIT
+
+## Batch demo from JSONL
+
+Use `scripts/demo_generate_from_jsonl.py` to render the same template for every JSON object in a JSONL file.
+
+Example input file path:
+
+- `templates/greeting/examples/sample_inputs.jsonl`
+
+Run:
+
+```bash
+python scripts/demo_generate_from_jsonl.py \
+  --project-root . \
+  --template-id greeting \
+  --input-jsonl templates/greeting/examples/sample_inputs.jsonl \
+  --output-dir output/demo
+```
+
+Outputs are written to `output/demo/<template_id>/<line_number>.txt`.

--- a/scripts/demo_generate_from_jsonl.py
+++ b/scripts/demo_generate_from_jsonl.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Batch demo renderer for template inputs stored as JSONL."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+if SRC_DIR.exists() and str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from templateer.env import TemplateEnv
+from templateer.errors import TemplateError
+from templateer.renderer import render_template_id
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render one template for each JSON object in a JSONL file.")
+    parser.add_argument("--project-root", type=Path, default=Path("."), help="Project root containing templates/registry.json")
+    parser.add_argument("--template-id", required=True, help="Template ID from templates/registry.json")
+    parser.add_argument("--input-jsonl", type=Path, required=True, help="Path to line-delimited JSON input file")
+    parser.add_argument("--output-dir", type=Path, default=Path("output/demo"), help="Directory where rendered files are written")
+    parser.add_argument("--fail-fast", action="store_true", help="Stop on the first parse/validation/render failure")
+    return parser
+
+
+def _write_output(base_output_dir: Path, template_id: str, line_number: int, content: str) -> Path:
+    template_output_dir = base_output_dir / template_id
+    template_output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = template_output_dir / f"{line_number}.txt"
+    output_path.write_text(content, encoding="utf-8")
+    return output_path
+
+
+def app(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    total = 0
+    success = 0
+    failure = 0
+
+    try:
+        with args.input_jsonl.open("r", encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                total += 1
+                line = raw_line.strip()
+                if not line:
+                    failure += 1
+                    print(f"line {line_number}: empty line", file=sys.stderr)
+                    if args.fail_fast:
+                        break
+                    continue
+
+                try:
+                    payload = json.loads(line)
+                    if not isinstance(payload, dict):
+                        raise ValueError("JSON value must be an object")
+
+                    env = TemplateEnv(args.project_root)
+                    rendered = render_template_id(env, args.template_id, payload)
+                    _write_output(args.output_dir, args.template_id, line_number, rendered)
+                    success += 1
+                except json.JSONDecodeError as exc:
+                    failure += 1
+                    print(f"line {line_number}: invalid JSON ({exc.msg})", file=sys.stderr)
+                    if args.fail_fast:
+                        break
+                except (TemplateError, ValueError) as exc:
+                    failure += 1
+                    print(f"line {line_number}: {exc}", file=sys.stderr)
+                    if args.fail_fast:
+                        break
+    except OSError as exc:
+        print(f"failed to read {args.input_jsonl}: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Processed {total} line(s): success={success}, failure={failure}")
+    return 1 if failure else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(app())


### PR DESCRIPTION
### Motivation

- Provide a small utility to demonstrate rendering the same template for many inputs stored as JSONL to simplify batch demos and acceptance testing.

### Description

- Add `scripts/demo_generate_from_jsonl.py`, a CLI script that accepts `--project-root` (default `.`), `--template-id` (required), `--input-jsonl` (required), `--output-dir` (default `output/demo`), and `--fail-fast` (flag) and renders one output per JSONL line.
- For each non-empty line the script builds `TemplateEnv(project_root)`, parses the line as JSON into a `dict`, calls `render_template_id(env, template_id, payload)`, and writes the result to `output_dir/<template_id>/<line_number>.txt` while tracking total/success/failure counts.
- On validation or render errors the script prints a concise message with the offending line number and continues unless `--fail-fast` is supplied, and it returns non-zero when any failures occurred and zero when all lines succeed.
- Update `README.md` with a new “Batch demo from JSONL” section that includes an example JSONL path (`templates/greeting/examples/sample_inputs.jsonl`) and an exact command to run the script.

### Testing

- Verified script syntax with `python -m py_compile scripts/demo_generate_from_jsonl.py`, which succeeded. 
- Attempted `python scripts/demo_generate_from_jsonl.py --help` but execution failed in this environment due to a missing runtime dependency (`pydantic`), so end-to-end execution against the project registry was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce7d78f648333961d2de7c05e75c8)