### PR TITLE
Add demo greeting and shared-header email templates with example models

### DIFF
--- a/src/templateer/examples/__init__.py
+++ b/src/templateer/examples/__init__.py
@@ -1,0 +1,5 @@
+"""Example TemplateModel classes for demo templates."""
+
+from templateer.examples.models import EmailTemplateModel, GreetingModel
+
+__all__ = ["GreetingModel", "EmailTemplateModel"]

--- a/src/templateer/examples/models.py
+++ b/src/templateer/examples/models.py
@@ -1,0 +1,23 @@
+"""Demo models used by example templates under ``templates/``."""
+
+from __future__ import annotations
+
+from templateer.model import TemplateModel
+
+
+class GreetingModel(TemplateModel):
+    """Input schema for ``templates/greeting/template.mako``."""
+
+    name: str
+    title: str | None = None
+
+
+class EmailTemplateModel(TemplateModel):
+    """Input schema for ``templates/email_with_shared_header/template.mako``."""
+
+    from_name: str
+    from_email: str
+    to_name: str
+    to_email: str
+    subject: str
+    body: str

--- a/templates/_shared/header.mako
+++ b/templates/_shared/header.mako
@@ -1,0 +1,4 @@
+From: ${from_name} <${from_email}>
+To: ${to_name} <${to_email}>
+Subject: ${subject}
+

--- a/templates/email_with_shared_header/README.md
+++ b/templates/email_with_shared_header/README.md
@@ -1,0 +1,31 @@
+# Email template with shared header
+
+This template includes a reusable shared header partial and then renders the email body.
+
+## Example input JSON
+
+```json
+{
+  "from_name": "Templateer Bot",
+  "from_email": "bot@example.com",
+  "to_name": "Ada Lovelace",
+  "to_email": "ada@example.com",
+  "subject": "Welcome!",
+  "body": "Thanks for trying Templateer. Let us know if you have any questions."
+}
+```
+
+## Expected rendered output
+
+```text
+From: Templateer Bot <bot@example.com>
+To: Ada Lovelace <ada@example.com>
+Subject: Welcome!
+
+Hello Ada Lovelace,
+
+Thanks for trying Templateer. Let us know if you have any questions.
+
+Best,
+Templateer Bot
+```

--- a/templates/email_with_shared_header/manifest.json
+++ b/templates/email_with_shared_header/manifest.json
@@ -1,0 +1,8 @@
+{
+  "model_import_path": "templateer.examples.models:EmailTemplateModel",
+  "description": "Demo email template that includes a shared header partial",
+  "tags": [
+    "demo",
+    "email"
+  ]
+}

--- a/templates/email_with_shared_header/template.mako
+++ b/templates/email_with_shared_header/template.mako
@@ -1,0 +1,7 @@
+<%include file="templates/_shared/header.mako"/>
+Hello ${to_name},
+
+${body}
+
+Best,
+${from_name}

--- a/templates/greeting/README.md
+++ b/templates/greeting/README.md
@@ -1,0 +1,21 @@
+# Greeting template
+
+A minimal template that demonstrates variable interpolation and one optional field.
+
+## Example input JSON
+
+```json
+{
+  "name": "Ada",
+  "title": "Engineer"
+}
+```
+
+## Expected rendered output
+
+```text
+Hello Ada!
+(Engineer)
+```
+
+If `title` is omitted, only the greeting line is rendered.

--- a/templates/greeting/manifest.json
+++ b/templates/greeting/manifest.json
@@ -1,0 +1,8 @@
+{
+  "model_import_path": "templateer.examples.models:GreetingModel",
+  "description": "Demo greeting template with an optional title",
+  "tags": [
+    "demo",
+    "greeting"
+  ]
+}

--- a/templates/greeting/template.mako
+++ b/templates/greeting/template.mako
@@ -1,0 +1,4 @@
+Hello ${name}!
+% if title:
+(${title})
+% endif


### PR DESCRIPTION
### Motivation
- Provide discoverable demo templates and matching Pydantic `TemplateModel` subclasses to serve as examples for registry building and rendering, including an example of a shared include partial.

### Description
- Add `templates/greeting/` with `template.mako`, `manifest.json` referencing `templateer.examples.models:GreetingModel`, and `README.md` demonstrating input/output.
- Add `templates/email_with_shared_header/` with `template.mako` that includes `templates/_shared/header.mako`, `manifest.json` referencing `templateer.examples.models:EmailTemplateModel`, and `README.md` with a complete sample payload and output.
- Add shared partial `templates/_shared/header.mako` used by the email template.
- Add example models in `src/templateer/examples/models.py` defining `GreetingModel` and `EmailTemplateModel` and export them from `src/templateer/examples/__init__.py`.

### Testing
- Validated both manifests with `python -m json.tool templates/greeting/manifest.json` and `python -m json.tool templates/email_with_shared_header/manifest.json` (success).
- Byte-compiled example module with `python -m compileall -q src/templateer/examples` (success).
- Ran `pytest -q tests/test_manifest.py tests/test_registry_builder.py tests/test_importers.py`, but test collection failed due to a missing dependency (`ModuleNotFoundError: No module named 'pydantic'`) in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce7d3afc48333b63d63fe7cb87d1d)