### PR TITLE
Align AGENT/SKILLS/README docs with refactor-first workflow guidance

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,171 +1,92 @@
-# AGENTS.md — Templateer (library + CLI) build guide
+# AGENTS.md — Templateer refactor guidance (services + `just` workflows)
 
-This repository implements **Templateer**, a convention-driven Python library + CLI for rendering **Mako** templates from **Pydantic** models, using an on-disk **JSON registry** as the single source of truth. This document translates the project concept into an implementation plan and acceptance criteria.
+This repository is moving from a CLI-centric implementation to a **service-first architecture** where CLI commands, scripts, and `just` recipes all share the same Python orchestration layer.
 
-## What “done” means (MVP)
+Use this guide when making changes so implementation and docs stay aligned with `CODE_REVIEW.md` and `JUST_REFACTOR.md`.
 
-- You can run:
-  - `mpt registry build --project-root <path>` to create `templates/registry.json` from per-template `manifest.json` files (no imports during build).
-  - `mpt render <template_id> --project-root <path> --json <file|->` to validate JSON via the registered model and render the registered template.
-- All template and include URIs are **root-relative**, must live under `templates/**`, and must be blocked from escaping via `..`.
-- Registry lookups **always** freshness-check the file on disk and reload+revalidate when it changes.
-- Rendering is **symlink-friendly**: operate on URIs + `project_root`, and avoid any logic that relies on `realpath()`.
+## Current refactor direction
 
----
+Templateer remains:
+- Registry-authoritative (`templates/registry.json` is source of truth)
+- Mako-based rendering
+- Pydantic model validation
 
-## Repo shape (recommended)
-
-```
-src/templateer/
-  __init__.py
-  env.py
-  registry.py
-  manifest.py
-  importers.py
-  uri.py
-  renderer.py
-  output.py
-  logging_.py
-  errors.py
-  cli.py
-tests/
-  ...
-```
-
-Keep the library independent of any “consumer project” layout beyond the required `project_root/` conventions.
+But workflow orchestration should converge on:
+- `templateer.services.*` for reusable business logic
+- Thin CLI wrappers (`templateer.cli`) for args + exit codes
+- Thin scripts and `Justfile` recipes that call service APIs/entrypoints
 
 ---
 
-## Architectural decisions (lock these in early)
+## Definition of done for refactor-aligned changes
 
-### 1) Registry is authoritative
-- The registry decides `template_uri` and `model_import_path`.
-- Any per-model hints (e.g., a class attribute) are *advisory* only and may be used for drift detection, never as the source of truth.
+A change is “aligned” when:
 
-### 2) URI-based security boundary
-Treat `template_uri` and include URIs as **posix-style** paths (regardless of OS). Enforce:
-- Must start with `templates/`
-- Must not be absolute
-- Must not contain `..` segments (after normalization)
-- Must not contain backslashes
-
-Do **not** try to “fix” URIs by resolving symlinks.
-
-### 3) Deterministic registry build
-Registry build reads manifests and filesystem structure only; it must not import arbitrary Python modules.
+1. **No new business logic is added directly to CLI command handlers** unless there is a short-term blocker.
+2. **Reusable workflow logic lives in service modules**, not duplicated across CLI/scripts.
+3. **`Justfile` remains declarative** (small recipes, minimal shell logic).
+4. **Input parsing/validation behavior is unified** (single public parsing path per input type).
+5. **Docs describe Mako + registry-first behavior accurately** (no legacy Jinja2 messaging).
 
 ---
 
-## Implementation plan (incremental)
+## Architectural guardrails (do not break)
 
-### Phase A — Core models and errors
-1. Implement exceptions (`errors.py`):
-   - `TemplateError` base
-   - `RegistryError`, `TemplateNotFoundError`, `TemplateImportError`, `TemplateRenderError`, `OutputWriteError`
-2. Implement Pydantic models (`registry.py`, `manifest.py`):
-   - `TemplateEntry`, `TemplateRegistry`
-   - `TemplateManifest` (min: `model_import_path`, optional `description`, `tags`)
-3. Implement URI validation utilities (`uri.py`).
+1. **Registry is authoritative**
+   - `template_id -> template_uri + model_import_path` mapping comes from registry.
+   - Do not let model classes override mapping at runtime.
 
-**Acceptance checks**
-- Invalid URIs are rejected with clear messages (include the offending URI).
+2. **URI security boundary**
+   - Template and include URIs are root-relative under `templates/**`.
+   - No absolute paths, backslashes, or traversal (`..`).
+   - Preserve symlink-friendly behavior (do not rely on realpath-based policy).
 
-### Phase B — Registry loading + freshness (`env.py`, `registry.py`)
-1. `TemplateEnv` holds:
-   - `project_root`, `templates_dir`, `output_dir`, `log_dir`
-   - `clock` callable returning UTC `datetime`
-2. Implement:
-   - `env.registry_path` → `templates/registry.json`
-   - `env.get_registry()` with freshness check:
-     - capture `stat().st_mtime_ns` + `st_size` (or inode too) for change detection
-     - on change: reload JSON, Pydantic-validate
-   - `env.get_entry(template_id)` convenience
+3. **Deterministic registry build**
+   - Registry generation must not import arbitrary model modules.
 
-**Acceptance checks**
-- Modify `registry.json` on disk; subsequent `get_entry()` sees changes without restarting the process.
-
-### Phase C — Model import (`importers.py`)
-Implement importing `pkg.module:ClassName`:
-- Validate the format (`:` separator, non-empty class name)
-- Import module, `getattr`, ensure it’s a Pydantic model subclass compatible with your `TemplateModel` base (or at least `BaseModel`)
-
-**Acceptance checks**
-- Bad import path yields `TemplateImportError` with actionable context.
-
-### Phase D — Mako rendering (`renderer.py`, `uri.py`)
-1. Create a safe Mako lookup that:
-   - Accepts root-relative URIs like `templates/invoice/template.mako`
-   - Enforces your URI policy for **both** render targets and includes
-   - Uses strict undefined
-   - Avoids compiled template cache output inside template trees
-
-2. Render flow:
-   - `env.get_entry(template_id)`
-   - import model
-   - parse input JSON → model instance (extra forbidden)
-   - render with context = `model.model_dump()`
-
-**Acceptance checks**
-- Include attempts like `../secrets.mako` fail fast.
-- Missing variables fail loudly (strict undefined).
-
-### Phase E — Output + logging (`output.py`, `logging_.py`)
-1. Output rules:
-   - `output/<template_id>/`
-   - safe filename validation: no separators, no `..`
-   - prefix timestamp: `YYYYMMDD-HHMMSSZ_...`
-2. Logging:
-   - append-only file at `log/mpt.log`
-   - JSONL or line-oriented key=val; include required fields from concept
-
-**Acceptance checks**
-- `--write` produces a file in the right folder with the right name shape.
-- Logs contain template_id, template_uri, model_import_path, and output path if written.
-
-### Phase F — CLI (`cli.py`)
-Expose commands:
-- `mpt registry build --project-root <path>`
-- `mpt registry show --project-root <path>`
-- `mpt render <template_id> --project-root <path> --json <file|-> [--write] [--filename ...]`
-- `mpt render-uri <template_uri> ...` (same restrictions)
-
-**Acceptance checks**
-- `--json -` reads stdin.
-- Exit codes are non-zero on errors; stderr has a concise message; logs contain details.
-
-### Phase G — Tests (`tests/`)
-Minimum suite:
-- URI validation tests (good/bad cases)
-- Registry reload tests (touch file, reload happens)
-- Registry build tests (manifests → registry output)
-- Rendering tests (strict undefined, include restrictions)
-- Symlink scenario tests (template folders symlinked under templates/)
+4. **Composable pipeline stages**
+   - Prefer explicit stages/functions: resolve entry, validate payload, render, persist artifacts.
 
 ---
 
-## Guardrails for agents
+## Recommended module shape (target)
 
-### Invariants (never break)
-- Registry is the only mapping authority.
-- Template/include URIs are validated and restricted to `templates/**`.
-- Build must not import models.
-- Rendering must not depend on symlink resolution.
+- `templateer.services.registry_service`
+  - build/load registry operations
+- `templateer.services.render_service`
+  - single render and multi-input render flows
+- `templateer.services.scaffold_service`
+  - template scaffold creation helpers
+- `templateer.services.output_service`
+  - artifact path creation + writes
+- `templateer.commands`
+  - optional thin command adapters used by CLI/scripts
 
-### Code style
-- Prefer small, composable functions with explicit inputs/outputs.
-- Put policy decisions in one place (URI rules in `uri.py`, registry freshness in `TemplateEnv`).
-
-### Error messages
-- Include: `template_id` or `template_uri`, and the action being attempted.
-- Prefer root-relative paths in user-facing errors.
+If full extraction is too large for one change, move one workflow at a time and keep behavior identical.
 
 ---
 
-## Suggested deliverables checklist
-- [ ] Library API: `TemplateEnv`, `TemplateModel.render()`
-- [ ] Registry models + loader with freshness
-- [ ] Deterministic registry builder
-- [ ] Safe Mako lookup (render + includes)
-- [ ] CLI wired to the above
-- [ ] Output writer + logger
-- [ ] Tests covering invariants and edge cases
+## `just` and scripts conventions
+
+- `Justfile` recipes should call Python entrypoints only.
+- Complex looping/branching belongs in Python, not inline shell in recipes.
+- Scripts under `scripts/` should be workflow-specific and import shared service modules.
+- Avoid copy-paste orchestration between CLI and scripts.
+
+---
+
+## Error handling and DX
+
+- User-facing errors should stay concise and contextual (`template_id`, action, relevant path).
+- Keep structured context in custom exceptions.
+- Preserve current non-zero exit behavior on command failures.
+
+---
+
+## Documentation alignment rules
+
+When editing docs:
+- Describe Templateer as **Mako + Pydantic + registry**.
+- Reference `generate` / `generate-examples` command surface (current), while marking service extraction as ongoing refactor.
+- Keep contributor guidance consistent with `JUST_REFACTOR.md` goals.
+

--- a/.agents/SKILLS.md
+++ b/.agents/SKILLS.md
@@ -1,0 +1,70 @@
+# SKILLS.md — Refactor skill map for Templateer contributors
+
+This file defines practical “skills” contributors should apply while executing the service-first refactor.
+
+## Skill: service-extraction
+
+**Use when:** CLI or script logic is growing and should be reusable.
+
+**Objective:** Move orchestration into `templateer.services` without changing behavior.
+
+**Checklist:**
+1. Locate workflow logic currently in `templateer/cli.py` or standalone script.
+2. Extract pure functions into a service module with explicit inputs/outputs.
+3. Keep CLI/script layer as thin adapters (arg parsing, printing, exit codes).
+4. Add or update tests around extracted service behavior.
+5. Remove duplicate code paths after extraction.
+
+---
+
+## Skill: input-validation-unification
+
+**Use when:** JSON/model payload parsing exists in multiple places.
+
+**Objective:** Ensure one canonical parsing/validation path per input source.
+
+**Checklist:**
+1. Identify duplicate parsers (CLI helpers, importer utilities, script-level parsing).
+2. Consolidate into shared function(s) in a stable module.
+3. Normalize error messages and exception types.
+4. Update callers to use the shared path.
+5. Verify CLI output remains concise and predictable.
+
+---
+
+## Skill: just-workflow-design
+
+**Use when:** Adding or changing automation recipes.
+
+**Objective:** Keep `Justfile` declarative and minimal.
+
+**Checklist:**
+1. Keep recipes short and composable.
+2. Call Python entrypoints/services; avoid embedded shell orchestration.
+3. Standardize common variables (`project_root`, interpreter, paths).
+4. Prefer one recipe per user-visible workflow.
+5. Document recipe intent in README and/or inline comments.
+
+---
+
+## Skill: docs-consistency
+
+**Use when:** Updating README, contributor docs, or template docs.
+
+**Objective:** Keep docs aligned with current architecture and refactor direction.
+
+**Checklist:**
+1. Describe current implementation accurately (Mako, registry-authoritative flows).
+2. Avoid stale references to Jinja2-centric behavior.
+3. Distinguish current behavior from target refactor architecture.
+4. Cross-check commands against `templateer.cli` and `Justfile`.
+5. Keep examples runnable with existing command names.
+
+---
+
+## Skill selection guidance
+
+- Prefer the smallest skill set needed for a change.
+- Combine skills only when necessary (e.g., `service-extraction` + `docs-consistency`).
+- If a change would add duplication, stop and apply `service-extraction` first.
+

--- a/README.md
+++ b/README.md
@@ -1,257 +1,103 @@
-# README.md
 # Templateer
 
-A minimal Python library for managing ~~Jinja2~~ Mako templates as Pydantic models. Checking in before kicking off refactor
+Templateer is a registry-authoritative Python library + CLI for generating files from **Mako** templates with **Pydantic**-validated inputs.
 
-## Installation
+This repository is currently in a refactor phase to support composable `just` workflows backed by shared Python service modules.
+
+## What Templateer does today
+
+- Builds a deterministic template registry from `templates/*/manifest.json`
+- Validates input payloads against registered model import paths
+- Renders registered Mako templates safely under `templates/**`
+- Writes generation artifacts for single-input and example-driven runs
+
+## Core concepts
+
+- **Registry is source of truth**: `templates/registry.json` maps `template_id` to `template_uri` and `model_import_path`
+- **URI safety policy**: templates/includes must remain under `templates/**` and cannot use traversal
+- **Mako-first rendering**: strict rendering behavior with guarded template lookup
+- **Environment freshness**: registry reads are reloaded when the on-disk file changes
+
+## Project layout
+
+```text
+src/templateer/
+  cli.py
+  env.py
+  registry.py
+  manifest.py
+  importers.py
+  renderer.py
+  output.py
+  uri.py
+  errors.py
+
+templates/
+  registry.json
+  <template-id>/
+    manifest.json
+    template.mako
+    examples/sample_inputs.jsonl
+```
+
+## CLI usage
+
+### Build registry
 
 ```bash
-uv add templateer
+PYTHONPATH=src python -m templateer.cli registry build --project-root .
 ```
 
-## Quick Start
-
-**1. Create a template in `.templateer/my_function.py`:**
-
-```python
-from __future__ import annotations
-from templateer import TemplateModel
-
-class MyFunctionTemplate(TemplateModel):
-    __template__ = TEMPLATE
-    
-    func_name: str
-    params: str = ""
-    return_type: str = "None"
-    docstring: str | None = None
-    body: str = "pass"
-
-
-TEMPLATE = """
-def {{ func_name }}({{ params }}) -> {{ return_type }}:
-    {% if docstring -%}
-    \"\"\"{{ docstring }}\"\"\"
-    {% endif -%}
-    {{ body|indent(4, true) }}
-"""
-```
-
-**2. Use it in your code:**
-
-```python
-from templateer import discover_templates
-
-# Auto-discover all templates in .templateer/
-templates = discover_templates()
-
-# Render to string
-template = templates.MyFunctionTemplate(
-    func_name="greet",
-    params="name: str",
-    return_type="str",
-    body='return f"Hello, {name}!"'
-)
-code = template.render()
-
-# Or write directly to file
-template.write_to("src/greet.py")
-```
-
-## How It Works
-
-1. **Create templates** as Pydantic models in `.templateer/` directory
-2. **Inherit from `TemplateModel`** to get rendering capabilities
-3. **Define `__template__`** as a Jinja2 template string
-4. **Use Pydantic fields** to define template variables
-5. **Call `.render()`** for string output or `.write_to(path)` to write files
-
-## Creating Templates
-
-Templates are Python classes that combine:
-- **Pydantic validation** for template data
-- **Jinja2 rendering** for code generation
-- **Type safety** via Python type hints
-
-### Template Structure
-
-```python
-from __future__ import annotations
-from templateer import TemplateModel
-
-class YourTemplate(TemplateModel):
-    __template__ = """
-    {{ your_jinja2_template_here }}
-    """
-    
-    # Define your fields with types and defaults
-    field_name: str
-    optional_field: int = 42
-```
-
-### Template Variables
-
-All Pydantic fields become Jinja2 template variables:
-
-```python
-class ConfigTemplate(TemplateModel):
-    __template__ = TEMPLATE
-    
-    app_name: str
-    debug: bool = False
-
-
-TEMPLATE = """
-APP_NAME = "{{ app_name }}"
-DEBUG = {{ debug }}
-"""
-```
-
-## API Reference
-
-### `TemplateModel`
-
-Base class for all templates. Provides:
-
-**`.render() -> str`**
-- Renders the template to a string
-- Uses Pydantic field values as Jinja2 context
-
-**`.write_to(path: str | Path) -> None`**
-- Renders template and writes to file
-- Creates parent directories if needed
-- Overwrites existing files
-
-### `discover_templates(directory: str | Path = ".templateer") -> object`
-
-- Scans directory for Python files
-- Imports all `TemplateModel` subclasses
-- Returns namespace object with templates as attributes
-- Template class names become attribute names
-
-## Project Structure
-
-```
-your-project/
-├── .templateer/
-│   ├── function_template.py
-│   ├── class_template.py
-│   └── cli_template.py
-├── src/
-│   └── # your generated code here
-└── generate.py  # your generation script
-```
-
-## Requirements
-
-- Python 3.10+
-- Pydantic 2.x
-- Jinja2
-
-## Template Composition
-
-Templates can be nested as Pydantic fields. Nested templates auto-render when used in Jinja2:
-
-**`.templateer/docstring.py`:**
-```python
-from __future__ import annotations
-from templateer import TemplateModel
-
-class DocstringTemplate(TemplateModel):
-    __template__ = TEMPLATE
-    
-    summary: str
-    params: list[str] = []
-
-
-TEMPLATE = """
-\"\"\"{{ summary }}
-{% if params %}
-
-Args:
-{% for param in params %}
-    {{ param }}
-{% endfor %}
-{% endif %}
-\"\"\"
-"""
-```
-
-**`.templateer/function_with_docs.py`:**
-```python
-from __future__ import annotations
-from templateer import TemplateModel
-from .docstring import DocstringTemplate
-
-class FunctionWithDocsTemplate(TemplateModel):
-    __template__ = TEMPLATE
-    
-    func_name: str
-    docstring: DocstringTemplate
-    body: str = "pass"
-
-
-TEMPLATE = """
-def {{ func_name }}():
-    {{ docstring|indent(4, true) }}
-    {{ body|indent(4, true) }}
-"""
-```
-
-**Usage:**
-```python
-template = FunctionWithDocsTemplate(
-    func_name="greet",
-    docstring=DocstringTemplate(
-        summary="Greet someone",
-        params=["name: Person to greet"]
-    ),
-    body="print('Hello!')"
-)
-code = template.render()
-```
-
-Nested `TemplateModel` instances automatically render when referenced in templates - no need to call `.render()` explicitly.
-
-## Design Principles
-
-- **Simple**: Just Pydantic + Jinja2, nothing more
-- **Type-safe**: Full editor support and validation
-- **Discoverable**: Auto-find templates without imports
-- **Minimal**: No magic, no complex abstractions
-- **Composable**: Nest templates as Pydantic fields
-- **Fast**: Render templates in milliseconds
-
-## Limitations
-
-- 1:1 template to output file mapping (one template class per output)
-- No reverse parsing (generated files → Pydantic models)
-
-## License
-
-MIT
-
-## Generation outputs and examples
-
-Each template directory contains:
-
-- `gen/` for ad-hoc generation runs from the CLI.
-- `examples/sample_inputs.jsonl` with sample input JSON objects.
-
-Single generation call:
+### Show registry
 
 ```bash
-mpt generate   --project-root .   --template-id greeting   --input-json '{"name":"Ada","title":"Engineer"}'
+PYTHONPATH=src python -m templateer.cli registry show --project-root .
 ```
 
-This writes a timestamped folder under `templates/greeting/gen/` with:
-
-- `input.json`
-- `output.txt`
-
-Generate all sample objects from JSONL:
+### Generate one output from inline JSON
 
 ```bash
-mpt generate-examples   --project-root .   --template-id greeting
+PYTHONPATH=src python -m templateer.cli generate \
+  --project-root . \
+  --template-id greeting \
+  --input-json '{"name":"Ada","title":"Engineer"}'
 ```
 
-This reads `templates/greeting/examples/sample_inputs.jsonl` and creates one timestamped folder per input object under `templates/greeting/examples/`.
+### Generate from examples JSONL
+
+```bash
+PYTHONPATH=src python -m templateer.cli generate-examples \
+  --project-root . \
+  --template-id greeting
+```
+
+## `just` workflows
+
+The `Justfile` is intended to stay thin and declarative.
+
+Common recipes:
+
+```bash
+just build-registry
+just create-template greeting my_app.models:GreetingModel
+just run-template-examples greeting
+just run-tests
+```
+
+## Refactor direction (in progress)
+
+As documented in `CODE_REVIEW.md` and `JUST_REFACTOR.md`, Templateer is moving to:
+
+- Shared service modules for orchestration (`templateer.services.*`)
+- Thin CLI wrappers (args + exit-code mapping only)
+- Thin scripts and `just` recipes that call shared services
+- Unified payload parsing/validation paths
+
+Contributors should keep new changes aligned with this direction and avoid adding new duplicated orchestration paths.
+
+## Development notes
+
+- Python: 3.10+
+- Tests: `PYTHONPATH=src python -m pytest -q`
+- License: MIT
+


### PR DESCRIPTION
## Summary
- rewrote `.agents/AGENTS.md` to align contributor guidance with the service-first, composable workflow direction from `CODE_REVIEW.md` and `JUST_REFACTOR.md`
- added `.agents/SKILLS.md` with focused contributor skill patterns for service extraction, input-validation unification, just workflow design, and docs consistency
- replaced stale root `README.md` content with an accurate Mako + Pydantic + registry-authoritative description of current CLI usage and in-progress refactor goals

## Why
The existing docs still reflected legacy assumptions (notably Jinja-centric framing and pre-refactor positioning). This update brings AGENT/SKILLS/README documentation in line with the intended architecture:
- thin CLI and just recipes
- shared orchestration via service modules
- unified validation paths
- registry-authoritative rendering model

## Validation
- static documentation update only (no code execution or tests run)
- verified commit includes only requested documentation files

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d03c4df38833387bdc0f0098b7678)