### PR TITLE
Add phased JUST_REFACTOR execution plan documents

### DIFF
--- a/JUST_REFACTOR_PHASE_1.md
+++ b/JUST_REFACTOR_PHASE_1.md
@@ -1,0 +1,51 @@
+# JUST_REFACTOR_PHASE_1
+
+## Objective
+Establish a stable execution surface so refactor work can proceed in parallel without churn in command invocations or path assumptions.
+
+## Scope
+- Keep `Justfile` orchestration-only.
+- Pin command conventions used by CLI and scripts.
+- Define shared runtime assumptions to prevent each phase from re-inventing bootstrap logic.
+
+## Implementation Tasks
+1. **Freeze command contract and naming**
+   - Confirm and document canonical command names in `src/templateer/cli.py` (`registry build`, `registry show`, `generate`, `generate-examples`).
+   - Document the expected output semantics (stdout for success artifacts, stderr for errors, non-zero exit on failure).
+   - Add explicit notes that these command names are compatibility-sensitive for future `just` and script wrappers.
+
+2. **Harden `Justfile` as a thin shell**
+   - Keep only orchestration recipes in `Justfile`.
+   - Ensure recipes call Python module/script entrypoints rather than embedding business logic.
+   - Standardize environment flags (`PYTHONPATH=src`, `--project-root`) across all recipes.
+
+3. **Create a shared script bootstrap utility**
+   - Add a helper module (e.g., `scripts/_bootstrap.py` or `src/templateer/services/runtime.py`) that resolves:
+     - project root
+     - python path assumptions
+     - common output directories
+   - Refactor existing scripts (`scripts/new_template.py`, `scripts/demo_generate_from_jsonl.py`) to consume this helper.
+
+4. **Define refactor guardrails**
+   - Add a short contributor note in `README.md` or `CONCEPT.md` stating:
+     - CLI is a public shell contract
+     - orchestration belongs in services
+     - `Justfile` should stay declarative
+
+## Parallelization Notes
+- This phase should land first.
+- It provides stable interfaces for Phases 2–6 and minimizes branch drift.
+
+## Testing Requirements
+1. **Static checks**
+   - Verify `Justfile` contains no inline Python logic beyond invoking entrypoints.
+   - Verify each recipe passes `--project-root` where applicable.
+
+2. **Behavioral tests to add/update**
+   - Add/update CLI tests in `tests/test_cli_generate.py` and `tests/test_dev_step_5.py` to assert command names and help surfaces remain unchanged.
+   - Add a script bootstrap unit test (new file under `tests/`) for root/path resolution behavior.
+
+3. **Validation checklist for completion**
+   - Existing command help snapshots still pass.
+   - No duplicated project-root bootstrap code remains in `scripts/` entrypoints.
+   - `Justfile` only orchestrates calls to modules/scripts.

--- a/JUST_REFACTOR_PHASE_2.md
+++ b/JUST_REFACTOR_PHASE_2.md
@@ -1,0 +1,54 @@
+# JUST_REFACTOR_PHASE_2
+
+## Objective
+Extract generation orchestration from `cli.py` into reusable service modules so CLI becomes a thin adapter.
+
+## Scope
+- Move `_generate_single`, `_generate_examples`, and JSON payload parsing flows out of CLI.
+- Preserve user-visible CLI behavior and exit code semantics.
+
+## Implementation Tasks
+1. **Create service-layer modules**
+   - Introduce `src/templateer/services/` package with modules such as:
+     - `generation_service.py`
+     - `registry_service.py`
+     - `input_service.py`
+   - Move command orchestration from `src/templateer/cli.py` into these modules.
+
+2. **Define stable service functions**
+   - Implement functions with clear contracts, e.g.:
+     - `generate_single(project_root, template_id, payload) -> Path`
+     - `generate_examples(project_root, template_id) -> tuple[int, int]`
+     - `parse_json_object(raw_json) -> dict[str, object]`
+   - Keep `TemplateError` and validation error boundaries explicit.
+
+3. **Slim down CLI**
+   - Update `src/templateer/cli.py` so `app()` only does:
+     - argument parsing
+     - service invocation
+     - stdout/stderr formatting
+     - exit code mapping
+   - Remove embedded rendering/write loops from CLI.
+
+4. **Keep compatibility guarantees**
+   - Preserve output messages and non-zero behavior expected by current tests and automation.
+
+## Parallelization Notes
+- This phase can run in parallel with Phase 3 after service interfaces are agreed.
+- Avoid editing `Justfile` in this phase to reduce merge conflicts with Phase 1/3.
+
+## Testing Requirements
+1. **Service unit tests**
+   - Add tests under `tests/` for new `templateer.services` functions:
+     - JSON object parsing failures/success
+     - single generation happy path
+     - example loop success/failure counters
+
+2. **CLI regression tests**
+   - Update `tests/test_cli_generate.py` and related CLI tests to verify no behavior drift.
+   - Ensure stderr messages for malformed JSON and template errors are still surfaced.
+
+3. **Validation checklist for completion**
+   - `src/templateer/cli.py` contains no business-loop logic for render/write.
+   - Service functions are directly callable from non-CLI code.
+   - CLI test suite continues to pass with unchanged command UX.

--- a/JUST_REFACTOR_PHASE_3.md
+++ b/JUST_REFACTOR_PHASE_3.md
@@ -1,0 +1,50 @@
+# JUST_REFACTOR_PHASE_3
+
+## Objective
+Normalize script architecture so scripts are thin entrypoints over shared services and can scale without copy-paste.
+
+## Scope
+- Standardize script conventions under `scripts/`.
+- Ensure scripts call service-layer APIs instead of duplicating orchestration.
+
+## Implementation Tasks
+1. **Define script conventions**
+   - Document conventions in `scripts/README` or root docs:
+     - one script = one workflow
+     - argument parsing only in script entrypoint
+     - business logic in `templateer.services`
+
+2. **Refactor existing scripts**
+   - Update `scripts/new_template.py` and `scripts/demo_generate_from_jsonl.py`:
+     - remove duplicated parsing/output logic
+     - delegate to shared helpers/services
+   - Evaluate `scripts/dev_watch` and align to same bootstrap/runtime assumptions.
+
+3. **Add shared script utilities**
+   - Create helper(s) for repetitive concerns:
+     - path normalization
+     - project-root discovery
+     - common error printing / exit behavior
+   - Keep these utilities minimal and generic.
+
+4. **Wire `Justfile` recipes to normalized scripts/services**
+   - Ensure each recipe targets a stable script or module command.
+   - Avoid hidden coupling to implementation details.
+
+## Parallelization Notes
+- Can proceed alongside Phase 2 once service interfaces are available.
+- Different contributors can own separate scripts if shared utility contracts are agreed early.
+
+## Testing Requirements
+1. **Script-focused tests**
+   - Add tests for script argument handling and integration boundaries (prefer subprocess-style tests if already used in repo patterns).
+   - Validate scripts fail fast and clearly on invalid arguments.
+
+2. **Cross-path consistency checks**
+   - For each workflow available via CLI and script, assert equivalent outputs for the same input.
+   - Add regression tests to ensure script behavior does not diverge from service behavior.
+
+3. **Validation checklist for completion**
+   - No script duplicates core render/validation logic already available in services.
+   - Shared utility is used by all maintained scripts.
+   - `Justfile` recipes reference standardized entrypoints only.

--- a/JUST_REFACTOR_PHASE_4.md
+++ b/JUST_REFACTOR_PHASE_4.md
@@ -1,0 +1,53 @@
+# JUST_REFACTOR_PHASE_4
+
+## Objective
+Refactor render flow into explicit, composable pipeline stages with structured run metadata.
+
+## Scope
+- Decompose rendering into discrete units that can be reused by CLI/scripts/services.
+- Introduce metadata-rich execution context for observability and CI usage.
+
+## Implementation Tasks
+1. **Define pipeline stage APIs**
+   - Introduce functions (module candidates: `src/templateer/services/pipeline.py`, `render_pipeline.py`) for:
+     - resolve template entry from registry
+     - validate/parse payload against model
+     - render template
+     - persist outputs
+
+2. **Introduce run metadata model**
+   - Add a dataclass/Pydantic-like struct (e.g., `RenderRunMetadata`) carrying:
+     - `template_id`
+     - run timestamp
+     - input source (inline JSON, JSONL path, line number)
+     - output artifact directory/path
+     - success/failure state and error details (if any)
+
+3. **Integrate metadata into output pathway**
+   - Update `src/templateer/output.py` integration points so metadata can be emitted/logged.
+   - Keep existing artifact structure backward compatible unless explicitly versioned.
+
+4. **Refactor callers to pipeline API**
+   - Update service and CLI layers to compose these stages rather than calling renderer/output ad hoc.
+
+## Parallelization Notes
+- Can run parallel with Phase 5 documentation work after stage contracts are drafted.
+- Coordinate carefully with Phase 2 to avoid duplicate service abstractions.
+
+## Testing Requirements
+1. **Stage-level unit tests**
+   - Add tests for each stage in isolation (resolve, validate, render, persist).
+   - Include negative-path tests for URI violations, model validation failures, and render undefined errors.
+
+2. **Metadata correctness tests**
+   - Assert metadata fields are populated accurately for both single-run and examples JSONL runs.
+   - Verify line-number attribution for JSONL failures.
+
+3. **End-to-end regression checks**
+   - Keep existing `tests/test_renderer.py`, `tests/test_uri*.py`, and CLI generation tests green.
+   - Add at least one integration test proving pipeline composition produces current artifact outputs.
+
+4. **Validation checklist for completion**
+   - Render flow can be assembled from pipeline stages without CLI imports.
+   - Metadata object is produced for every render attempt.
+   - Existing external behavior remains compatible.

--- a/JUST_REFACTOR_PHASE_5.md
+++ b/JUST_REFACTOR_PHASE_5.md
@@ -1,0 +1,51 @@
+# JUST_REFACTOR_PHASE_5
+
+## Objective
+Align documentation and developer UX with actual Mako-based architecture and new service-driven workflows.
+
+## Scope
+- Remove implementation drift in docs.
+- Provide clear onboarding and troubleshooting for refactored workflows.
+
+## Implementation Tasks
+1. **README modernization**
+   - Update `README.md` sections to be explicitly Mako-first.
+   - Reflect service-layer architecture and thin CLI/Justfile patterns.
+   - Add examples for direct service usage where appropriate.
+
+2. **Document `just` workflows deeply**
+   - Expand usage docs for each supported recipe:
+     - expected inputs
+     - expected outputs
+     - common failures
+   - Include sequence examples (e.g., scaffold -> build-registry -> generate-examples).
+
+3. **Troubleshooting section**
+   - Add concise troubleshooting for:
+     - missing `templates/registry.json`
+     - malformed `manifest.json`
+     - invalid model import paths
+     - template URI policy violations
+
+4. **Developer contribution guidance**
+   - Add short architecture notes on where to place:
+     - business logic (`templateer.services`)
+     - command adapters (`cli.py`, scripts)
+     - schema/contract code (`manifest.py`, `registry.py`)
+
+## Parallelization Notes
+- Can run in parallel with engineering phases once interfaces stabilize.
+- Merge near the end to reduce rework from code movement.
+
+## Testing Requirements
+1. **Docs consistency checks (static)**
+   - Verify every documented command exists and uses current flags.
+   - Verify module paths and filenames match actual repository structure.
+
+2. **Executable example verification plan**
+   - For each code snippet in README/Just docs, add or update a smoke test where feasible (or ensure snippets match tested commands in existing tests).
+
+3. **Validation checklist for completion**
+   - No Jinja2-first wording remains where implementation is Mako.
+   - Docs mention service-layer architecture and thin adapters consistently.
+   - Troubleshooting examples map to real error classes/messages.

--- a/JUST_REFACTOR_PHASE_6.md
+++ b/JUST_REFACTOR_PHASE_6.md
@@ -1,0 +1,62 @@
+# JUST_REFACTOR_PHASE_6
+
+## Objective
+Perform integration hardening and release-readiness checks across the completed refactor, with emphasis on parallel branch reconciliation.
+
+## Scope
+- Consolidate all phase outputs.
+- Resolve cross-phase conflicts and ensure behavior parity.
+- Finalize test and CI expectations for long-term maintainability.
+
+## Implementation Tasks
+1. **Cross-phase merge strategy execution**
+   - Reconcile changes touching shared hotspots:
+     - `src/templateer/cli.py`
+     - `Justfile`
+     - script entrypoints under `scripts/`
+     - new `src/templateer/services/` modules
+   - Prefer service API contracts as the conflict-resolution source of truth.
+
+2. **Behavior parity audit**
+   - Compare pre/post refactor behavior for:
+     - command outputs
+     - exit codes
+     - artifact paths and filenames
+     - error message ergonomics
+
+3. **Quality gate definition**
+   - Add/confirm baseline CI checks:
+     - unit tests
+     - integration tests for CLI/script parity
+     - optional lint/type checks if enabled
+
+4. **Refactor completion report**
+   - Add a short summary document (`JUST_REFACTOR_STATUS.md` or README section) listing:
+     - what moved into services
+     - what stayed as adapters
+     - known follow-up items
+
+## Parallelization Notes
+- This is the convergence phase and should run after feature phases are merged.
+- Keep this phase focused on reconciliation/testing, not introducing new architecture.
+
+## Testing Requirements
+1. **Full-suite regression run**
+   - Run complete test suite and ensure green.
+   - Add targeted regression cases for previously conflict-prone paths.
+
+2. **CLI/script parity matrix**
+   - Validate equivalent workflows through:
+     - CLI invocation path
+     - script invocation path
+     - `just` recipe path
+   - Ensure identical success/failure semantics.
+
+3. **Non-functional checks**
+   - Confirm no significant performance regressions in example batch generation path.
+   - Validate logs/metadata outputs are deterministic enough for CI troubleshooting.
+
+4. **Validation checklist for completion**
+   - No unresolved TODOs from Phases 1–5.
+   - All quality gates pass.
+   - Final architecture is documented and consistent with code.


### PR DESCRIPTION
## Summary
- added six new planning documents: `JUST_REFACTOR_PHASE_1.md` through `JUST_REFACTOR_PHASE_6.md`
- translated the high-level `JUST_REFACTOR.md` guidance into detailed, step-by-step implementation scopes
- included explicit testing requirements and completion checklists for each phase
- organized phase boundaries and dependency notes to maximize parallel execution and reduce merge-conflict risk

## Details
- **Phase 1**: stabilize command surface and environment/bootstrap assumptions
- **Phase 2**: extract orchestration from CLI into reusable service modules
- **Phase 3**: normalize script architecture around shared services/utilities
- **Phase 4**: refactor render flow into explicit composable pipeline stages + run metadata
- **Phase 5**: align docs/dev UX with Mako-first, service-driven architecture
- **Phase 6**: convergence and integration hardening with parity/regression gating

## Testing
- no runtime tests executed in this change (documentation-only planning artifacts)
- each phase doc now contains concrete test requirements to validate implementation when that phase is executed

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d099838988333a6a01512ca6162ae)