### PR TITLE
docs: expand README with just workflow details and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,204 @@ just run-template-examples greeting
 just run-tests
 ```
 
+### `build-registry`
+
+**Purpose**
+
+Builds `templates/registry.json` by scanning `templates/*/manifest.json` and validating each template entry.
+
+**Inputs / arguments**
+
+- No positional arguments.
+- Uses `python` and `project_root` variables from `Justfile` (defaults: `python`, `.`).
+- Effective command:
+
+  ```bash
+  PYTHONPATH=src python -m templateer.cli registry build --project-root .
+  ```
+
+**Resulting files / side effects**
+
+- Creates or replaces `templates/registry.json` atomically.
+- Fails fast if required template files are missing (`manifest.json`, `template.mako`, `README.md`).
+
+**Common failures and likely fixes**
+
+- `manifest file does not exist` / `manifest validation failed while building registry`
+  - Add or fix `templates/<id>/manifest.json`.
+- `manifest is not valid JSON`
+  - Fix malformed JSON (trailing commas/comments are not allowed).
+- `manifest contains unknown fields`
+  - Keep only `model_import_path`, `description`, `tags`.
+- `template missing required file`
+  - Ensure each template folder contains `manifest.json`, `template.mako`, and `README.md`.
+
+### `create-template <template_id> <model_import_path> [description] [tags]`
+
+**Purpose**
+
+Scaffolds a new template folder under `templates/<template_id>/` and rebuilds registry.
+
+**Inputs / arguments**
+
+- Required positional args:
+  - `template_id` (must match `[a-zA-Z0-9][a-zA-Z0-9_-]*`)
+  - `model_import_path` (expected `pkg.module:ClassName`)
+- Optional positional args:
+  - `description` (default empty string; scaffold service fills fallback text)
+  - `tags` (comma-separated string)
+
+**Resulting files / side effects**
+
+- Creates these files/directories if missing:
+  - `templates/<template_id>/manifest.json`
+  - `templates/<template_id>/template.mako`
+  - `templates/<template_id>/README.md`
+  - `templates/<template_id>/examples/sample_inputs.jsonl`
+  - `templates/<template_id>/gen/.gitkeep`
+- Rebuilds `templates/registry.json`.
+
+**Common failures and likely fixes**
+
+- `template-id cannot be empty` / `template-id must match [a-zA-Z0-9][a-zA-Z0-9_-]*`
+  - Provide a valid identifier (no spaces/slashes).
+- `Template already exists and is not empty`
+  - Choose another id, or clean/reuse existing template directory.
+- Registry build errors after scaffold
+  - Resolve the manifest/template/README issues in the newly created template and rerun `just build-registry`.
+
+### `run-template-examples <template_id>`
+
+**Purpose**
+
+Builds registry, then renders each line in `templates/<template_id>/examples/sample_inputs.jsonl`.
+
+**Inputs / arguments**
+
+- Required positional arg: `template_id`.
+- Implicit prerequisite: runs `build-registry` first.
+
+**Resulting files / side effects**
+
+- Reads `templates/<template_id>/examples/sample_inputs.jsonl`.
+- For each valid JSON object line, writes a timestamped artifact directory under `templates/<template_id>/examples/` containing:
+  - `input.json`
+  - `output.txt`
+- Prints a summary: `Processed examples: success=<n>, failure=<m>`.
+- Returns non-zero exit code when any failures occur.
+
+**Common failures and likely fixes**
+
+- `line <n>: input is not valid JSON (...)`
+  - Fix invalid JSON syntax in that JSONL line.
+- `line <n>: input JSON must be an object at the top level`
+  - Ensure each line is an object (`{...}`), not an array/string/number.
+- `<template_id> not found in registry`
+  - Run `just build-registry`, confirm template id, and check `templates/registry.json`.
+- Render/URI errors such as `Template URI must remain under templates/`
+  - Fix template include/render URIs so they stay within `templates/**`.
+
+### `run-tests`
+
+**Purpose**
+
+Runs the full test suite via `pytest`.
+
+**Inputs / arguments**
+
+- No positional arguments.
+- Effective command:
+
+  ```bash
+  PYTHONPATH=src python -m pytest -q
+  ```
+
+**Resulting files / side effects**
+
+- Executes unit/integration tests.
+- May create temporary test artifacts depending on test behavior.
+
+**Common failures and likely fixes**
+
+- `ModuleNotFoundError` or import errors
+  - Confirm dependencies are installed and run from repo root with `PYTHONPATH=src`.
+- Assertion failures in registry/manifest/URI tests
+  - Rebuild registry, then inspect template manifests and URIs for policy compliance.
+
+## Troubleshooting
+
+### Missing `templates/registry.json`
+
+Symptoms:
+
+- `registry file does not exist`
+- CLI commands that depend on registry fail (for example `registry show`, `generate`, `generate-examples`).
+
+What to do:
+
+1. Run `just build-registry` from repository root.
+2. Confirm `templates/registry.json` now exists.
+3. If build still fails, resolve the reported manifest/template file issues first.
+
+### Malformed `templates/<id>/manifest.json`
+
+Symptoms:
+
+- `manifest is not valid JSON`
+- `manifest validation failed`
+- `manifest contains unknown fields`
+
+What to do:
+
+1. Ensure JSON is syntactically valid.
+2. Keep only supported keys: `model_import_path`, `description`, `tags`.
+3. Ensure `tags` is a list of strings and `description` is a string (if present).
+
+### Invalid `model_import_path`
+
+Symptoms:
+
+- `model_import_path is required`
+- `model_import_path must use 'pkg.module:ClassName' format`
+- `model_import_path module must be a dotted python import path`
+- `model_import_path class must be a valid python identifier`
+
+What to do:
+
+1. Use the exact `pkg.module:ClassName` format.
+2. Ensure module segments are valid Python identifiers separated by dots.
+3. Ensure class name is a valid Python identifier.
+
+### Template URI policy violations under `templates/**`
+
+Symptoms:
+
+- `Template URI cannot be absolute`
+- `Template URI cannot contain path traversal segments`
+- `Template URI must remain under templates/`
+- `Template URI must use POSIX separators and cannot contain backslashes`
+
+What to do:
+
+1. Keep all template and include URIs relative to `templates/`.
+2. Do not use `..` traversal.
+3. Do not use absolute paths.
+4. Use forward slashes (`/`) only.
+
+## Contribution guidance
+
+When adding or refactoring code, keep responsibilities explicit:
+
+- **Business logic**
+  - Place orchestration/domain workflows in `src/templateer/services/*`.
+- **Command adapters**
+  - Keep CLI argument parsing and exit-code mapping in `src/templateer/cli.py`.
+  - Keep script wrappers/adapters in `scripts/*`.
+- **Schema/contracts**
+  - Place manifest schema/validation contracts in `src/templateer/manifest.py`.
+  - Place registry schema/validation contracts in `src/templateer/registry.py`.
+  - Keep closely related contract/types modules aligned with those schema boundaries.
+
 
 ## CLI compatibility contract
 
@@ -122,4 +320,3 @@ Contributors should keep new changes aligned with this direction and avoid addin
 - Python: 3.10+
 - Tests: `PYTHONPATH=src python -m pytest -q`
 - License: MIT
-


### PR DESCRIPTION
### Motivation

- Clarify the `just`-based developer workflows so contributors can run and understand the repository orchestration without guessing implied inputs or side effects. 
- Surface common failure modes (registry/manifest/URI/model import problems) and practical fixes to reduce iteration time when scaffolding or rendering templates. 
- Make contribution boundaries explicit so new code is placed in the intended modules and the refactor direction is easier to follow.

### Description

- Extended the `README.md` `just` workflows section with per-recipe documentation for `build-registry`, `create-template`, `run-template-examples`, and `run-tests`, including required inputs/arguments, resulting files/side effects, and common failure messages with likely fixes. 
- Added a Troubleshooting section that covers missing `templates/registry.json`, malformed `templates/<id>/manifest.json`, invalid `model_import_path`, and template URI policy violations under `templates/**`. 
- Added Contribution guidance that maps responsibilities to locations in the codebase: business logic to `src/templateer/services/*`, CLI adapters to `src/templateer/cli.py` and `scripts/*`, and schema/contracts to `src/templateer/manifest.py` and `src/templateer/registry.py`. 
- The only code file changed is `README.md` to improve documentation and developer guidance.

### Testing

- Ran the test suite with `PYTHONPATH=src python -m pytest -q`, and test collection failed during import with `ModuleNotFoundError: No module named 'pydantic'`, indicating a missing test dependency in the environment. 
- No other automated checks were executed as part of this change due to the dependency error preventing test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d1f2a90148333b1ff01162d8e650c)