### PR TITLE
Complete Step 6 refactor convergence and fix JSONL error-type regressions

### DIFF
--- a/JUST_REFACTOR_STATUS.md
+++ b/JUST_REFACTOR_STATUS.md
@@ -1,0 +1,37 @@
+# JUST_REFACTOR_STATUS
+
+## Refactor completion summary
+
+### What moved into `templateer.services`
+- Input parsing and top-level JSON object validation moved to `src/templateer/services/input_service.py`.
+- Generation orchestration moved to `src/templateer/services/generation_service.py`:
+  - single render workflow (`generate_single`)
+  - JSONL batch workflow (`process_jsonl_inputs`)
+  - examples workflow (`generate_examples`)
+- Render pipeline stages were made explicit in `src/templateer/services/pipeline.py`:
+  - registry resolution
+  - payload validation against model import path
+  - URI render stage
+  - artifact persistence wrappers
+- Shared runtime/bootstrap helpers are centralized in `src/templateer/services/runtime.py`.
+
+### What stayed as adapters
+- `src/templateer/cli.py` remains a thin command adapter:
+  - argument parsing
+  - invocation of service functions
+  - stdout/stderr message and exit-code mapping
+- `scripts/new_template.py` and `scripts/demo_generate_from_jsonl.py` remain thin script entrypoints over services.
+- `Justfile` remains orchestration-only and delegates behavior to CLI/scripts.
+
+### Quality gates
+- Unit and integration tests under `tests/` cover services, CLI, scripts, and refactor steps.
+- `just run-tests` is the baseline CI quality gate.
+- Phase 6 parity/regression checks now include:
+  - stable render-attempt error categorization for template failures (`TemplateError`)
+  - CLI/script workflow parity checks for example generation outcomes
+  - static checks that `Justfile` routes workflows through supported entrypoints
+
+### Known follow-up items
+- Add optional lint/type quality gates once tool choices are finalized (`just lint`, `just typecheck`).
+- Consider adding machine-readable structured logs for CI ingestion.
+- Add an explicit performance benchmark harness for large JSONL batch generation.

--- a/src/templateer/services/generation_service.py
+++ b/src/templateer/services/generation_service.py
@@ -15,6 +15,14 @@ from templateer.services.metadata import GenerationBatchResult, RenderAttemptMet
 from templateer.services.pipeline import render_template_uri, resolve_registry_entry, validate_payload_with_model_import_path
 
 
+def _classify_error_type(exc: Exception) -> str:
+    """Return stable error categories for render-attempt metadata."""
+
+    if isinstance(exc, TemplateError):
+        return "TemplateError"
+    return type(exc).__name__
+
+
 def render_template_id(env: TemplateEnv, template_id: str, payload: dict[str, object]) -> str:
     """Render ``template_id`` for one payload after validation."""
 
@@ -55,7 +63,7 @@ def generate_single(project_root: Path, template_id: str, payload: dict[str, obj
             line_number=None,
             output_artifact_path=None,
             success=False,
-            error_type=type(exc).__name__,
+            error_type=_classify_error_type(exc),
             error_message=str(exc),
             run_metadata=run_metadata,
         )
@@ -128,7 +136,7 @@ def process_jsonl_inputs(
                         line_number=line_number,
                         output_artifact_path=None,
                         success=False,
-                        error_type=type(exc).__name__,
+                        error_type=_classify_error_type(exc),
                         error_message=str(exc),
                         error_details=line,
                         run_metadata=run_metadata,

--- a/tests/test_refactor_step_06.py
+++ b/tests/test_refactor_step_06.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from templateer.cli import app
+
+
+def _write_template(template_dir: Path, model_import_path: str) -> None:
+    template_dir.mkdir(parents=True, exist_ok=True)
+    (template_dir / "template.mako").write_text("Hello ${name}!", encoding="utf-8")
+    (template_dir / "README.md").write_text("# Template", encoding="utf-8")
+    (template_dir / "manifest.json").write_text(
+        json.dumps({"model_import_path": model_import_path, "description": "desc", "tags": ["a"]}),
+        encoding="utf-8",
+    )
+
+
+def _setup_project(tmp_path: Path) -> None:
+    _write_template(tmp_path / "templates" / "greeting", "templateer.examples.models:GreetingModel")
+    result = app(["registry", "build", "--project-root", str(tmp_path)])
+    assert result == 0
+
+
+def _run_subprocess(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    return subprocess.run(command, cwd=cwd, env=env, text=True, capture_output=True, check=False)
+
+
+def test_step_06_status_doc_exists_and_records_phase_convergence() -> None:
+    status_text = Path("JUST_REFACTOR_STATUS.md").read_text(encoding="utf-8")
+
+    assert "What moved into `templateer.services`" in status_text
+    assert "What stayed as adapters" in status_text
+    assert "Quality gates" in status_text
+    assert "Known follow-up items" in status_text
+
+
+
+def test_step_06_cli_and_script_generation_paths_preserve_failure_semantics(tmp_path: Path) -> None:
+    _setup_project(tmp_path)
+
+    examples_dir = tmp_path / "templates" / "greeting" / "examples"
+    examples_dir.mkdir(parents=True, exist_ok=True)
+    sample_jsonl = examples_dir / "sample_inputs.jsonl"
+    sample_jsonl.write_text('{"name":"Ada"}\n\n{"name": 3}\n', encoding="utf-8")
+
+    cli_result = _run_subprocess(
+        [
+            sys.executable,
+            "-m",
+            "templateer.cli",
+            "generate-examples",
+            "--project-root",
+            str(tmp_path),
+            "--template-id",
+            "greeting",
+        ],
+        cwd=Path.cwd(),
+    )
+
+    script_out = tmp_path / "script_out"
+    script_result = _run_subprocess(
+        [
+            sys.executable,
+            "scripts/demo_generate_from_jsonl.py",
+            "--project-root",
+            str(tmp_path),
+            "--template-id",
+            "greeting",
+            "--input-jsonl",
+            str(sample_jsonl),
+            "--output-dir",
+            str(script_out),
+        ],
+        cwd=Path.cwd(),
+    )
+
+    assert cli_result.returncode == 1
+    assert script_result.returncode == 1
+
+    assert "success=1, failure=2" in cli_result.stdout
+    assert "success=1, failure=2" in script_result.stdout
+    assert "line 2: empty line" in cli_result.stderr
+    assert "line 3:" in cli_result.stderr
+    assert "line 2: empty line" in script_result.stderr
+    assert "line 3:" in script_result.stderr
+
+    cli_generations = sorted(path for path in examples_dir.iterdir() if path.is_dir())
+    script_generations = sorted(path for path in script_out.iterdir() if path.is_dir())
+    assert len(cli_generations) == 1
+    assert len(script_generations) == 1
+
+
+
+def test_step_06_justfile_defines_expected_quality_gate_entrypoints() -> None:
+    justfile_text = Path("Justfile").read_text(encoding="utf-8")
+
+    assert "run-tests:" in justfile_text
+    assert "python -m pytest -q" in justfile_text
+
+    assert "run-template-examples template_id: build-registry" in justfile_text
+    assert "python -m templateer.cli generate-examples" in justfile_text
+    assert "--project-root {{project_root}}" in justfile_text
+
+    assert "create-template template_id model_import_path" in justfile_text
+    assert "scripts/new_template.py" in justfile_text


### PR DESCRIPTION
## Summary
- completed Phase 6 convergence deliverables by adding `JUST_REFACTOR_STATUS.md` with:
  - service-layer migration summary
  - adapter boundary summary (CLI/scripts/Justfile)
  - quality gate expectations
  - known follow-up items
- fixed JSONL/generation metadata regression where template validation failures were reported as `TemplateValidationError` instead of the stable category expected by tests
  - added stable error classification helper in `generation_service`
  - template-derived exceptions now map to `TemplateError`
- added `tests/test_refactor_step_06.py` to cover Step 6 outcomes:
  - status document presence/content
  - CLI vs script failure-semantic parity for example generation
  - Justfile quality-gate and entrypoint wiring checks

## Why
- roadmap Phase 6 requires convergence hardening, parity checks, and a completion report
- user-reported failing tests expected `TemplateError` classification for failed template rows in JSONL processing

## Validation
- attempted targeted pytest run for the two reported failures and new Step 6 tests
- environment is missing required dependencies (notably `pydantic`), so test execution could not complete in this container
- attempted dependency installation but package index access/build dependency resolution is blocked in this environment

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d2063e72c8333881db4f09f042ab0)